### PR TITLE
cli wrapper for expected

### DIFF
--- a/cooltools/cli/__init__.py
+++ b/cooltools/cli/__init__.py
@@ -22,5 +22,5 @@ def cli():
 from . import (
     dump_cworld,
     diamond_insulation,
-    expected,
+    compute_expected,
 )

--- a/cooltools/cli/__init__.py
+++ b/cooltools/cli/__init__.py
@@ -22,4 +22,5 @@ def cli():
 from . import (
     dump_cworld,
     diamond_insulation,
+    expected,
 )

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -101,7 +101,8 @@ def compute_expected(cool_path, nproc, chunksize, chrom_region_type):
         # chrom_region_type ...
         raise click.NoSuchOption('Field numbers are one-based')
 
-    # output to stdout:
+    # output to stdout,
+    # just like in diamond_insulation:
     print(expected_result.to_csv(sep='\t', index=True, na_rep='nan'))
 
     # # DO WE HAVE TO SHUT DOWN SUCH CLUSTERS AT ALL ? ...

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -60,7 +60,7 @@ from .. import expected
     required=True
     )
 
-def expected(cool_path, nproc, chunksize, chrom_region_type):
+def compute_expected(cool_path, nproc, chunksize, chrom_region_type):
     """
     Calculate either expected Hi-C singal
     either for cis or for trans regions of

--- a/cooltools/cli/expected.py
+++ b/cooltools/cli/expected.py
@@ -85,7 +85,7 @@ def expected(cool_path, nproc, chunksize, chrom_region_type):
         # list of regions in a format (chrom,start,stop),
         # when start,stop ommited, process entire chrom:
         regions = [ (chrom,) for chrom in c.chromnames ]
-        expected_result = cis_expected(clr=c,
+        expected_result = expected.cis_expected(clr=c,
                                        regions=regions,
                                        field='balanced',
                                        chunksize=chunksize,
@@ -93,7 +93,7 @@ def expected(cool_path, nproc, chunksize, chrom_region_type):
                                        ignore_diags=2)
     elif chrom_region_type == 'trans':
         # process for all chromosomes:
-        expected_result = trans_expected(clr=c,
+        expected_result = expected.trans_expected(clr=c,
                                          chromosomes=c.chromnames,
                                          chunksize=chunksize,
                                          use_dask=use_dask)

--- a/cooltools/cli/expected.py
+++ b/cooltools/cli/expected.py
@@ -1,0 +1,54 @@
+import click
+
+import cooler
+
+from . import cli
+from .. import expected
+
+@cli.command()
+@click.argument(
+    "cool_path",
+    metavar="COOL_PATH",
+    type=str,
+    nargs=1)
+@click.option(
+    '--cis-trans-type',
+    help="compute expected for cis or trans region"
+    "of a Hi-C map.",
+    type=click.Choice(['cis', 'trans']),
+    default='cis',
+    show_default=True,
+    )
+
+
+
+def expected(cool_path, window, min_dist_bad_bin, ignore_diags):
+    """
+    Calculate either cis- or trans- expected.
+    
+    COOL_PATH : The paths to a .cool file with a balanced Hi-C map.
+
+    cis-trans-type
+
+    number of cores to split the work between.
+
+    """
+
+    c = cooler.Cooler(cool_path)
+
+    if cis_trans_type == 'cis':
+        # expected_result = cis_expected(clr, regions, field='balanced', chunksize=1000000, 
+        #                  use_dask=True, ignore_diags=2):
+    elif cis_trans_type == 'trans':
+        # expected_result = trans_expected(clr, chromosomes, chunksize=1000000, use_dask=False)
+    else:
+        # cis_trans_type could be either cis or trans ...
+        raise
+    # ins_table = insulation.find_insulating_boundaries(
+    #     c, window_bp = window, min_dist_bad_bin = min_dist_bad_bin,
+    #     ignore_diags=ignore_diags)
+
+    print(expected_result.to_csv(sep='\t', index=True, na_rep='nan'))
+
+
+

--- a/cooltools/cli/expected.py
+++ b/cooltools/cli/expected.py
@@ -60,7 +60,7 @@ from .. import expected
     required=True
     )
 
-def expected(cool_path):
+def expected(cool_path, nproc, chunksize, chrom_region_type):
     """
     Calculate either expected Hi-C singal
     either for cis or for trans regions of

--- a/cooltools/cli/expected.py
+++ b/cooltools/cli/expected.py
@@ -5,6 +5,13 @@ import cooler
 from . import cli
 from .. import expected
 
+
+
+# might be relevant to us ...
+# https://stackoverflow.com/questions/46577535/how-can-i-run-a-dask-distributed-local-cluster-from-the-command-line
+# http://distributed.readthedocs.io/en/latest/setup.html#using-the-command-line
+
+
 @cli.command()
 @click.argument(
     "cool_path",
@@ -12,43 +19,100 @@ from .. import expected
     type=str,
     nargs=1)
 @click.option(
-    '--cis-trans-type',
+    '--nproc', '-n',
+    help="Number of processes to split the work between."
+         "[default: 1, i.e. no process pool]",
+    default=1,
+    type=int)
+@click.option(
+    "--chunksize", "-c",
+    help="Control the number of pixels handled by each worker process at a time.",
+    type=int,
+    default=int(10e6),
+    show_default=True)
+# instead of Choice:
+# @click.option(
+#     '--cis-trans-type',
+#     help="compute expected for cis or trans region"
+#     "of a Hi-C map.",
+#     type=click.Choice(['cis', 'trans']),
+#     default='cis',
+#     show_default=True,
+#     )
+# use
+# feature switch for --cis/--trans:
+# http://click.pocoo.org/options/#feature-switches
+# http://click.pocoo.org/parameters/#parameter-names
+@click.option(
+    '--cis',
+    'chrom_region_type',
     help="compute expected for cis or trans region"
     "of a Hi-C map.",
-    type=click.Choice(['cis', 'trans']),
-    default='cis',
-    show_default=True,
+    flag_value='cis',
+    required=True
+    )
+@click.option(
+    '--trans',
+    'chrom_region_type',
+    help="compute expected for cis or trans region"
+    "of a Hi-C map.",
+    flag_value='trans',
+    required=True
     )
 
-
-
-def expected(cool_path, window, min_dist_bad_bin, ignore_diags):
+def expected(cool_path):
     """
-    Calculate either cis- or trans- expected.
+    Calculate either expected Hi-C singal
+    either for cis or for trans regions of
+    chromosomal interaction map.
     
     COOL_PATH : The paths to a .cool file with a balanced Hi-C map.
 
-    cis-trans-type
-
-    number of cores to split the work between.
-
     """
 
+    if nproc > 1:
+        import distributed
+        cluster = distributed.LocalCluster(n_workers=nproc)
+        client = distributed.Client(cluster)
+    # use dask if more than 1 process requested:
+    use_dask = True if nproc > 1 else False
+
+    # load cooler file to process:
     c = cooler.Cooler(cool_path)
 
-    if cis_trans_type == 'cis':
-        # expected_result = cis_expected(clr, regions, field='balanced', chunksize=1000000, 
-        #                  use_dask=True, ignore_diags=2):
-    elif cis_trans_type == 'trans':
-        # expected_result = trans_expected(clr, chromosomes, chunksize=1000000, use_dask=False)
+    # execute EITHER cis OR trans (not both):
+    if chrom_region_type == 'cis':
+        # list of regions in a format (chrom,start,stop),
+        # when start,stop ommited, process entire chrom:
+        regions = [ (chrom,) for chrom in c.chromnames ]
+        expected_result = cis_expected(clr=c,
+                                       regions=regions,
+                                       field='balanced',
+                                       chunksize=chunksize,
+                                       use_dask=use_dask,
+                                       ignore_diags=2)
+    elif chrom_region_type == 'trans':
+        # process for all chromosomes:
+        expected_result = trans_expected(clr=c,
+                                         chromosomes=c.chromnames,
+                                         chunksize=chunksize,
+                                         use_dask=use_dask)
     else:
-        # cis_trans_type could be either cis or trans ...
-        raise
-    # ins_table = insulation.find_insulating_boundaries(
-    #     c, window_bp = window, min_dist_bad_bin = min_dist_bad_bin,
-    #     ignore_diags=ignore_diags)
+        # chrom_region_type ...
+        raise click.NoSuchOption('Field numbers are one-based')
 
+    # output to stdout:
     print(expected_result.to_csv(sep='\t', index=True, na_rep='nan'))
 
-
+    # # DO WE HAVE TO SHUT DOWN SUCH CLUSTERS AT ALL ? ...
+    # # ############
+    # # # Shut down the whole distributed cluster
+    # # # business, to avoid interference ...
+    # # ############
+    # if nproc > 1:
+    #     # client.shutdown(timeout=1)
+    #     # print(client.status)
+    #     for w in cluster.workers:
+    #         cluster.stop_worker(w)
+    #     cluster.close()
 


### PR DESCRIPTION
Simple CLI wrapper for expected.py:

```
cooltools compute_expected --cis in.cool
cooltools compute_expected --trans in.cool
```
Using bunch of cores:
```
cooltools compute_expected -n 8 --cis in.cool
cooltools compute_expected -n 8 --trans in.cool (would raise NotImplemented)
```
NOTES:

Wrapper works fine with the latest `dask`(0.17.0) and `distributed`(1.21.0).
Only `stdout` output is implemented, just like for `diamond_insulation`.

TODO:
 - Should probably add `ignore_diags` as a `click` option - will do later.
 - Improve my usage of `click` options - i provided links to `click` features I tried to use, but `help` looks ugly a bit.
 - do we have to explicitly shutdown `distributed`  cluster ?