### PR TITLE
w,p variables scope fix

### DIFF
--- a/cooltools/cli/call_dots.py
+++ b/cooltools/cli/call_dots.py
@@ -105,8 +105,7 @@ def scoring_step(clr, expected, expected_name, tiles, kernels,
                  max_nans_tolerated, loci_separation_bins, output_path, 
                  nproc, verbose):
     if verbose:
-        print("Preparing to convolve "
-              "{} tiles with w,p={},{} kernels".format(len(tiles),w,p))
+        print("Preparing to convolve {} tiles:".format(len(tiles)))
 
     # add very_verbose to supress output from convolution of every tile
     very_verbose = False
@@ -517,6 +516,9 @@ def call_dots(
         raise ValueError("Provided cooler {} has resolution {} bases, \
                         which is too fine for analysis.".format(cool_path, binsize))
     # rename w, p to wid, pix probably, or _w, _p to avoid naming conflicts ...
+    if verbose:
+        print("Kernels parameters are set as w,p={},{}"
+              " for the cooler with {} bp resolution.".format(w,p,binsize))
 
     kernels = {k: get_kernel(w,p,k) for k in ktypes}
 


### PR DESCRIPTION
addressing https://github.com/mirnylab/cooltools/issues/27

just a variables scope bug, that is activated only with `verbose` output