### PR TITLE
eigdecomp.py: remove a leading slash in load_attrs [ignore_diags]

### DIFF
--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -297,7 +297,7 @@ def cooler_cis_eig(
         )
 
     ignore_diags = (
-        clr._load_attrs('/bins/weight')['ignore_diags']
+        clr._load_attrs('bins/weight')['ignore_diags']
         if ignore_diags is None
         else ignore_diags)
 


### PR DESCRIPTION
master keeps running ahead ...