### PR TITLE
Granular query machinery for diamond insulation

### DIFF
--- a/cooltools/insulation.py
+++ b/cooltools/insulation.py
@@ -1,22 +1,24 @@
 import warnings
 import numpy as np
 import pandas as pd
+import cooler
+from .lib._query import CSRSelector
 from .lib import peaks, numutils
 
 
-def insul_diamond(pixels, bins,
-        window=10, ignore_diags=2, balanced=True, norm_by_median=True):
+def insul_diamond(pixel_query, bins, window=10, ignore_diags=2, balanced=True,
+                  norm_by_median=True):
     """
     Calculates the insulation score of a Hi-C interaction matrix.
 
     Parameters
     ----------
-    pixels : pandas.DataFrame
-        A table of Hi-C interactions. Must follow the Cooler columnar format: 
+    pixel_query : RangeQuery object <TODO:update description>
+        A table of Hi-C interactions. Must follow the Cooler columnar format:
         bin1_id, bin2_id, count, balanced (optional)).
-    
+
     bins : pandas.DataFrame
-        A table of bins, is used to determine the span of the matrix 
+        A table of bins, is used to determine the span of the matrix
         and the locations of bad bins.
 
     window : int
@@ -24,54 +26,57 @@ def insul_diamond(pixels, bins,
 
     ignore_diags : int
         If > 0, the interactions at separations < `ignore_diags` are ignored
-        when calculating the insulation score. Typically, a few first diagonals 
+        when calculating the insulation score. Typically, a few first diagonals
         of the Hi-C map should be ignored due to contamination with Hi-C
         artifacts.
 
     norm_by_median : bool
         If True, normalize the insulation score by its NaN-median.
-    
-    
-    """
 
+    """
     lo_bin_id = bins.index.min()
     hi_bin_id = bins.index.max() + 1
     N = hi_bin_id - lo_bin_id
     sum_pixels = np.zeros(N)
     n_pixels = np.zeros(N)
-
     bad_bin_mask = bins.weight.isnull().values if balanced else np.zeros(N, dtype=bool)
 
-    diag_pixels = pixels[pixels.bin2_id - pixels.bin1_id <= (window - 1) * 2]
-    if balanced: 
-        diag_pixels = diag_pixels[~diag_pixels.balanced.isnull()]
+    for chunk_dict in pixel_query.read_chunked():
+        chunk = pd.DataFrame(chunk_dict, columns=['bin1_id', 'bin2_id', 'count'])
+        diag_pixels = chunk[chunk.bin2_id - chunk.bin1_id <= (window - 1) * 2]
+        if balanced:
+            diag_pixels = cooler.annotate(diag_pixels, bins[['weight']])
+            diag_pixels['balanced'] = (
+                diag_pixels['count'] * diag_pixels['weight1'] *
+                diag_pixels['weight2']
+            )
+            diag_pixels = diag_pixels[~diag_pixels['balanced'].isnull()]
 
-    i = diag_pixels.bin1_id.values - lo_bin_id
-    j = diag_pixels.bin2_id.values - lo_bin_id
-    val = diag_pixels.balanced.values if balanced else diag_pixels['count'].values
+        i = diag_pixels.bin1_id.values - lo_bin_id
+        j = diag_pixels.bin2_id.values - lo_bin_id
+        val = diag_pixels.balanced.values if balanced else diag_pixels['count'].values
 
-    for i_shift in range(0, window):
-        for j_shift in range(0, window):
-            if i_shift+j_shift < ignore_diags:
-                continue
+        for i_shift in range(0, window):
+            for j_shift in range(0, window):
+                if i_shift+j_shift < ignore_diags:
+                    continue
 
-            mask = (i+i_shift == j-j_shift) & (i + i_shift < N ) & (j - j_shift >= 0 ) 
+                mask = (i+i_shift == j-j_shift) & (i + i_shift < N ) & (j - j_shift >= 0 )
 
-            sum_pixels += np.bincount(i[mask] + i_shift, val[mask], minlength=N)
+                sum_pixels += np.bincount(i[mask] + i_shift, val[mask], minlength=N)
 
-            loc_bad_bin_mask = np.zeros(N, dtype=bool)
-            if i_shift == 0:
-                loc_bad_bin_mask |= bad_bin_mask
-            else:
-                loc_bad_bin_mask[i_shift:] |= bad_bin_mask[:-i_shift]
-            if j_shift == 0:
-                loc_bad_bin_mask |= bad_bin_mask
-            else:
-                loc_bad_bin_mask[:-j_shift] |= bad_bin_mask[j_shift:]
+                loc_bad_bin_mask = np.zeros(N, dtype=bool)
+                if i_shift == 0:
+                    loc_bad_bin_mask |= bad_bin_mask
+                else:
+                    loc_bad_bin_mask[i_shift:] |= bad_bin_mask[:-i_shift]
+                if j_shift == 0:
+                    loc_bad_bin_mask |= bad_bin_mask
+                else:
+                    loc_bad_bin_mask[:-j_shift] |= bad_bin_mask[j_shift:]
 
-            n_pixels[i_shift:(-j_shift if j_shift else None)] += (
-                 1 - loc_bad_bin_mask[i_shift:(-j_shift if j_shift else None)])
-
+                n_pixels[i_shift:(-j_shift if j_shift else None)] += (
+                     1 - loc_bad_bin_mask[i_shift:(-j_shift if j_shift else None)])
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -83,10 +88,11 @@ def insul_diamond(pixels, bins,
 
     return score
 
+
 def find_insulating_boundaries(
     clr,
     window_bp=100000,
-    min_dist_bad_bin=2, 
+    min_dist_bad_bin=2,
     balance='weight',
     ignore_diags=None,
     chromosomes=None,
@@ -100,43 +106,50 @@ def find_insulating_boundaries(
     window_bp : int or list
         The size of the sliding diamond window used to calculate the insulation
         score. If a list is provided, then a insulation score if done for each
-        value of window_bp.   
+        value of window_bp.
     min_dist_bad_bin : int
         The minimal allowed distance to a bad bin. Do not calculate insulation
         scores for bins having a bad bin closer than this distance.
     ignore_diags : int
-        The number of diagonals to ignore. If None, equals the number of 
+        The number of diagonals to ignore. If None, equals the number of
         diagonals ignored during IC balancing.
 
     Returns
     -------
     ins_table : pandas.DataFrame
-        A table containing the insulation scores of the genomic bins and 
+        A table containing the insulation scores of the genomic bins and
         the insulating boundary strengths.
     '''
     if chromosomes is None:
         chromosomes = clr.chromnames
 
     bin_size = clr.info['bin-size']
-    ignore_diags = (ignore_diags 
-        if ignore_diags is not None 
+    ignore_diags = (ignore_diags
+        if ignore_diags is not None
         else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'] )
 
     if isinstance(window_bp, int):
         window_bp = [window_bp]
     window_bp = np.array(window_bp)
     window_bins = window_bp // bin_size
-    
-    bad_win_sizes = window_bp % bin_size !=0 
+
+    bad_win_sizes = window_bp % bin_size !=0
     if np.any(bad_win_sizes):
         raise Exception(
             'The window sizes {} has to be a multiple of the bin size {}'.format(
                 window_bp[bad_win_sizes], bin_size))
-        
+
+    # XXX -- Use a delayed query executor
+    nbins = len(clr.bins())
+    selector = CSRSelector(
+        clr.open('r'),
+        shape=(nbins, nbins),
+        field='count',
+        chunksize=10000000)
+
     ins_chrom_tables = []
     for chrom in chromosomes:
         chrom_bins = clr.bins().fetch(chrom)
-        chrom_pixels = clr.matrix(as_pixels=True, balance=balance).fetch(chrom)
 
         is_bad_bin = np.isnan(chrom_bins['weight'].values)
         bad_bin_neighbor = np.zeros_like(is_bad_bin)
@@ -145,26 +158,34 @@ def find_insulating_boundaries(
                 bad_bin_neighbor = bad_bin_neighbor | is_bad_bin
             else:
                 bad_bin_neighbor = bad_bin_neighbor | np.r_[[True]*i, is_bad_bin[:-i]]
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True]*i]            
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True]*i]
 
         ins_chrom = chrom_bins[['chrom', 'start', 'end']].copy()
         ins_chrom['bad_bin_masked'] = bad_bin_neighbor
 
+        #chrom_pixels = clr.matrix(as_pixels=True, balance=balance).fetch(chrom)
+
+        # XXX --- Create a delayed selection
+        c0, c1 = clr.extent(chrom)
+        chrom_query = selector[c0:c1, c0:c1]
 
         for j, win_bin in enumerate(window_bins):
-            with warnings.catch_warnings():                      
-                warnings.simplefilter("ignore", RuntimeWarning)  
-                ins_track = insul_diamond(chrom_pixels, chrom_bins, 
-                                          window=win_bin, ignore_diags=ignore_diags)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                ins_track = insul_diamond(  # XXX -- updated insul_diamond
+                    chrom_query,
+                    chrom_bins,
+                    window=win_bin,
+                    ignore_diags=ignore_diags)
                 ins_track[ins_track==0] = np.nan
                 ins_track = np.log2(ins_track)
-        
+
             ins_track[bad_bin_neighbor] = np.nan
             ins_track[~np.isfinite(ins_track)] = np.nan
-        
+
             ins_chrom['log2_insulation_score_{}'.format(window_bp[j])] = ins_track
 
-            poss, proms = peaks.find_peak_prominence(-ins_track)	
+            poss, proms = peaks.find_peak_prominence(-ins_track)
             ins_prom_track = np.zeros_like(ins_track) * np.nan
             ins_prom_track[poss] = proms
             ins_chrom['boundary_strength_{}'.format(window_bp[j])] = ins_prom_track
@@ -182,21 +203,21 @@ def _insul_diamond_dense(mat, window=10, ignore_diags=2, norm_by_median=True):
     Parameters
     ----------
     mat : numpy.array
-        A dense square matrix of Hi-C interaction frequencies. 
+        A dense square matrix of Hi-C interaction frequencies.
         May contain nans, e.g. in rows/columns excluded from the analysis.
-    
+
     window : int
         The width of the window to calculate the insulation score.
 
     ignore_diags : int
         If > 0, the interactions at separations < `ignore_diags` are ignored
-        when calculating the insulation score. Typically, a few first diagonals 
+        when calculating the insulation score. Typically, a few first diagonals
         of the Hi-C map should be ignored due to contamination with Hi-C
         artifacts.
 
     norm_by_median : bool
         If True, normalize the insulation score by its NaN-median.
-    
+
     """
     if (ignore_diags):
         mat = mat.copy()
@@ -221,7 +242,7 @@ def _find_insulating_boundaries_dense(
     clr,
     window_bp=100000,
     balance='weight',
-    min_dist_bad_bin=2, 
+    min_dist_bad_bin=2,
     ignore_diags=None,
     chromosomes=None,
 ):
@@ -238,29 +259,29 @@ def _find_insulating_boundaries_dense(
         The minimal allowed distance to a bad bin. Do not calculate insulation
         scores for bins having a bad bin closer than this distance.
     ignore_diags : int
-        The number of diagonals to ignore. If None, equals the number of 
+        The number of diagonals to ignore. If None, equals the number of
         diagonals ignored during IC balancing.
 
     Returns
     -------
     ins_table : pandas.DataFrame
-        A table containing the insulation scores of the genomic bins and 
+        A table containing the insulation scores of the genomic bins and
         the insulating boundary strengths.
     '''
     if chromosomes is None:
         chromosomes = clr.chromnames
 
     bin_size = clr.info['bin-size']
-    ignore_diags = (ignore_diags 
-        if ignore_diags is not None 
+    ignore_diags = (ignore_diags
+        if ignore_diags is not None
         else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'] )
     window_bins = window_bp // bin_size
-    
+
     if (window_bp % bin_size !=0):
         raise Exception(
             'The window size ({}) has to be a multiple of the bin size {}'.format(
                 window_bp, bin_size))
-        
+
     ins_chrom_tables = []
     for chrom in chromosomes:
         ins_chrom = clr.bins().fetch(chrom)[['chrom', 'start', 'end']]
@@ -268,26 +289,26 @@ def _find_insulating_boundaries_dense(
 
         m = clr.matrix(balance=balance).fetch(chrom)
 
-        with warnings.catch_warnings():                      
-            warnings.simplefilter("ignore", RuntimeWarning)  
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
             ins_track = _insul_diamond_dense(
                 m, window_bins, ignore_diags)
             ins_track[ins_track==0] = np.nan
             ins_track = np.log2(ins_track)
-        
+
         bad_bin_neighbor = np.zeros_like(is_bad_bin)
         for i in range(0, min_dist_bad_bin):
             if i == 0:
                 bad_bin_neighbor = bad_bin_neighbor | is_bad_bin
             else:
                 bad_bin_neighbor = bad_bin_neighbor | np.r_[[True]*i, is_bad_bin[:-i]]
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True]*i]            
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True]*i]
 
         ins_track[bad_bin_neighbor] = np.nan
         ins_chrom['bad_bin_masked'] = bad_bin_neighbor
-        
+
         ins_track[~np.isfinite(ins_track)] = np.nan
-        
+
         ins_chrom['log2_insulation_score_{}'.format(window_bp)] = ins_track
 
         poss, proms = peaks.find_peak_prominence(-ins_track)

--- a/cooltools/lib/_query.py
+++ b/cooltools/lib/_query.py
@@ -1,0 +1,170 @@
+from collections import defaultdict
+import numpy as np
+import pandas as pd
+#from scipy.sparse import coo_matrix
+from cooler.core import _IndexingMixin
+
+
+def arg_prune_partition(seq, step):
+    """
+    Take a monotonic sequence of integers and downsample it such that they
+    are at least ``step`` apart (roughly), preserving the first and last
+    elements. Returns indices, not values.
+
+    """
+    lo, hi = seq[0], seq[-1]
+    num = 2 + (hi - lo) // step
+    cuts = np.linspace(lo, hi, num, dtype=int)
+    return np.unique(np.searchsorted(seq, cuts))
+
+
+class CSRSelector(_IndexingMixin):
+    """
+    Instantiates 2D range queries.
+
+    Example
+    -------
+    >>> selector = CSRSelector(h5, (100, 100), 'count', 10000)
+    >>> query = selector[lo1:hi1, lo2:hi2]
+
+    """
+    def __init__(self, grp, shape, field, chunksize):
+        self.grp = grp
+        self.shape = shape
+        self.field = field
+        self.chunksize = chunksize
+        self.offset_selector = grp['indexes']['bin1_offset']
+        self.bin1_selector = grp['pixels']['bin1_id']
+        self.bin2_selector = grp['pixels']['bin2_id']
+        self.data_selector = grp['pixels'][field]
+
+    def _make_getchunk(self, ispan, jspan):
+        # Factory for function that executes any piece of a 2D range query by
+        # index.
+
+        bin1_selector = self.bin1_selector
+        bin2_selector = self.bin2_selector
+        data_selector = self.data_selector
+        field = self.field
+        i0, i1 = ispan
+        j0, j1 = jspan
+
+        # coarsegrain the offsets to extract a big chunk of rows at a time
+        if (i1 - i0 < 1) or (j1 - j0 < 1):
+            offsets = []
+            loc_pruned_offsets = []
+        else:
+            offsets = self.offset_selector[i0:i1 + 1]
+            loc_pruned_offsets = arg_prune_partition(offsets, self.chunksize)
+
+        self._loc_pruned_offsets = loc_pruned_offsets
+        #i0 -- matrix row number offset
+        #o0 -- corresponding pixel id offset = offsets[0]
+
+        # let's take the downsampled subset of pixel id offsets [o0, ...., o1]
+        # each successive pair corresponds to a "piece" of the query
+        def getchunk(chunk_id, include_index=False):
+            out = {
+                'bin1_id': [],
+                'bin2_id': [],
+                field: []
+            }
+            if include_index:
+                out['__index'] = []
+
+            # extract a chunk of on-disk rows
+            oi, of = loc_pruned_offsets[chunk_id], loc_pruned_offsets[chunk_id+1]
+            p0, p1 = offsets[oi], offsets[of]
+            slc = slice(p0, p1)
+
+            bin2_extracted = bin2_selector[slc]
+            data_extracted = data_selector[slc]
+            if include_index:
+                ind_extracted = np.arange(slc.start, slc.stop)
+
+            # go row by row and filter
+            for i in range(oi, of):
+                # correct the offsets
+                lo = offsets[i] - p0
+                hi = offsets[i + 1] - p0
+
+                # this row
+                bin2 = bin2_extracted[lo:hi]
+
+                # filter for the range of j values we want
+                mask = (bin2 >= j0) & (bin2 < j1)
+                cols = bin2[mask]
+
+                # apply same mask for data
+                data = data_extracted[lo:hi][mask]
+
+                # shortcut for row data
+                rows = np.full(len(cols), i0 + i, dtype=bin1_selector.dtype)
+
+                out['bin1_id'].append(rows)
+                out['bin2_id'].append(cols)
+                out[field].append(data)
+                if include_index:
+                    out['__index'].append(ind_extracted[lo:hi][mask])
+
+            if len(out):
+                for k in out.keys():
+                    out[k] = np.concatenate(out[k], axis=0)
+            else:
+                out['bin1_id'] = np.array([], dtype=bin1_selector.dtype)
+                out['bin2_id'] = np.array([], dtype=bin2_selector.dtype)
+                out[field]     = np.array([], dtype=data_selector.dtype)
+                if include_index:
+                    out['__index'] = np.array([], dtype=np.int64)
+
+            return out
+
+        return getchunk, loc_pruned_offsets
+
+    def __getitem__(self, key):
+        s1, s2 = self._unpack_index(key)
+        ispan = self._process_slice(s1, self.shape[0])
+        jspan = self._process_slice(s2, self.shape[1])
+        getchunk, loc_pruned_offsets = self._make_getchunk(ispan, jspan)
+        return RangeQuery(self, ispan, jspan, self.field, getchunk,
+                          loc_pruned_offsets)
+
+
+class RangeQuery(object):
+    """
+    Executor that fulfills a partitioned 2D range query using a variety of outputs.
+
+    """
+    def __init__(self, selector, ispan, jspan, field, getchunk, loc_pruned_offsets):
+        self.selector = selector
+        self.ispan = ispan
+        self.jspan = jspan
+        self.field = field
+        self.n_chunks = len(loc_pruned_offsets) - 1
+        self._locs = loc_pruned_offsets
+        self._getchunk = getchunk
+
+    def read_chunk(self, i, include_index=False):
+        """Read any chunk of the partitioned query as a dictionary."""
+        if not 0 <= i < self.n_chunks:
+            raise IndexError(i)
+        return self._getchunk(i, include_index)
+
+    def read_chunked(self, include_index=False):
+        """Iterator over chunks (as dictionaries)."""
+        for i in range(self.n_chunks):
+            yield self._getchunk(i, include_index)
+
+    def read(self, include_index=False):
+        """Read the complete range query as a dictionary"""
+        result = list(self.read_chunked(include_index))
+        return {
+            k: np.concatenate([d[k] for d in result], axis=0)
+               for k in ['bin1_id', 'bin2_id', self.field]
+        }
+
+    def __repr__(self):
+        return ('{self.__class__.__name__}'
+                '({self.ispan}, {self.jspan}, "{self.field}", ...) '
+                '[{n} piece(s)]').format(
+                   self=self, n=self.n_chunks)


### PR DESCRIPTION
This PR adds a private `lib._query` that allows taking large delayed range queries and materializing them in smaller pieces, to reduce memory constraints: e.g. selecting a whole chromosome for computing insulation score at very high resolutions. We can begin using it in different cooltools and adjust the API until we are happy with it, at which point it can be migrated into cooler. This PR updates insulation score to use the new machinery.

ping @sergpolly in case this might be useful for dots