### PR TITLE
Parse setup dependencies from requirements file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,14 +4,7 @@ channels:
   - bioconda
 dependencies:
   - numpy
-  - scipy
   - cython
   - matplotlib
-  - pandas
-  - h5py
-  - numba
-  - dask
-  - scikit-learn
-  - cooler
-  - click
-  - pytest
+  - pip:
+    - -r requirements-dev.txt

--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,6 @@ dependencies:
   - numpy
   - cython
   - matplotlib
+  - pip
   - pip:
     - -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+bioframe
+click>=7
+cooler>=0.8.5
+cython
+cytoolz
+joblib
+matplotlib
+multiprocess
+numba
+numpy
+pandas
+scikit-learn
+scipy
+tables

--- a/setup.py
+++ b/setup.py
@@ -41,27 +41,22 @@ def get_long_description():
     return _read('README.md')
 
 
+def get_requirements(path):
+    content = _read(path)
+    return [
+        req
+        for req in content.split("\n")
+        if req != '' and not req.startswith('#')
+    ]
+
+
 setup_requires = [
     'cython',
     'numpy',
 ]
 
 
-install_requires = [
-    'click>=7',
-    'cooler>=0.8.5',
-    'bioframe',
-    'cython',
-    'numba',
-    'numpy',
-    'scipy',
-    'pandas',
-    'multiprocess',
-    'cytoolz',
-    'scikit-learn',
-    'tables',
-    'joblib',
-]
+install_requires = get_requirements('requirements.txt')
 
 
 extensions = [


### PR DESCRIPTION
* Add requirements and requirements-dev files. To be kept loosely pinned.
* Add matplotlib to requirements
* Parse `install_requires` from requirements.txt

* [x] <strike>modify travis to use requirements instead of environment.yml</strike> make environment.yml use requirements!