### PR TITLE
flake8 + coverage + black

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+source=
+    cooltools/
+
+omit=
+    cooltools/__main__.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    return NotImplemented
+    raise NotImplementedError

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,18 @@
+[flake8]
+exclude =
+    __init__.py
+    __main__.py
+
+max-line-length = 80
+ignore =
+    E203  # whitespace before ':'
+    E266  # too many leading '#' for block comment
+    E501  # line too long
+    W503  # line break before binary operator
+select =
+    C  # mccabe complexity
+    E  # pycodestyle
+    F  # pyflakes error
+    W  # pyflakes warning
+    B  # bugbear
+    B950  # line exceeds max-line-length + 10%

--- a/cooltools/__init__.py
+++ b/cooltools/__init__.py
@@ -11,7 +11,8 @@ The tools for your .cool's.
 
 """
 import logging
-__version__ = '0.3.0'
+
+__version__ = "0.3.0"
 
 from . import io
 from . import lib

--- a/cooltools/__main__.py
+++ b/cooltools/__main__.py
@@ -1,4 +1,4 @@
 from .cli import cli
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/cooltools/balance.py
+++ b/cooltools/balance.py
@@ -59,7 +59,7 @@ def bnewt(matvec, mask, tol=1e-6, x0=None, delta=0.1, Delta=3, fl=0):
     eta = etamax
     stop_tol = tol * 0.5
     x = x0
-    rt = tol**2
+    rt = tol ** 2
     v = x * matvec(x, mask)
 
     rk = 1 - v
@@ -68,17 +68,17 @@ def bnewt(matvec, mask, tol=1e-6, x0=None, delta=0.1, Delta=3, fl=0):
     rold = rout
 
     MVP = 0  # We’ll count matrix vector products.
-    i = 0    # Outer iteration count.
+    i = 0  # Outer iteration count.
 
     if fl == 1:
-        print('it in. it res', flush=True)
+        print("it in. it res", flush=True)
 
     # Outer iteration
     while rout > rt:
         i += 1
         k = 0
         y = e.copy()
-        innertol = max((eta**2)*rout, rt)
+        innertol = max((eta ** 2) * rout, rt)
 
         # Inner iteration by Conjugate Gradient
         while rho_km1 > innertol:
@@ -90,13 +90,13 @@ def bnewt(matvec, mask, tol=1e-6, x0=None, delta=0.1, Delta=3, fl=0):
                 rho_km1 = np.dot(rk, Z)
             else:
                 beta = rho_km1 / rho_km2
-                p = Z + beta*p
+                p = Z + beta * p
 
             # Update search direction efficiently.
-            w = x * matvec(x*p, mask) + v*p
+            w = x * matvec(x * p, mask) + v * p
 
             alpha = rho_km1 / np.dot(p, w)
-            ap = alpha*p
+            ap = alpha * p
 
             # Test distance to boundary of cone.
             ynew = y + ap
@@ -105,17 +105,17 @@ def bnewt(matvec, mask, tol=1e-6, x0=None, delta=0.1, Delta=3, fl=0):
                     break
                 idx = ap < 0
                 gamma = np.min((delta - y[idx]) / ap[idx])
-                y = y + gamma*ap
+                y = y + gamma * ap
                 break
 
             if max(ynew) >= Delta:
                 idx = ynew > Delta
-                gamma = np.min((Delta-y[idx]) / ap[idx])
-                y = y + gamma*ap
+                gamma = np.min((Delta - y[idx]) / ap[idx])
+                y = y + gamma * ap
                 break
 
             y = ynew.copy()
-            rk = rk - alpha*w
+            rk = rk - alpha * w
             rho_km2 = rho_km1
             Z = rk / v
             rho_km1 = np.dot(rk, Z)
@@ -129,20 +129,20 @@ def bnewt(matvec, mask, tol=1e-6, x0=None, delta=0.1, Delta=3, fl=0):
         MVP += k + 1
 
         # Update inner iteration stopping criterion.
-        rat = rout/rold
+        rat = rout / rold
         rold = rout
         res_norm = np.sqrt(rout)
         eta_o = eta
         eta = g * rat
-        if g*(eta_o**2) > 0.1:
-            eta = max(eta, g*(eta_o**2))
+        if g * (eta_o ** 2) > 0.1:
+            eta = max(eta, g * (eta_o ** 2))
 
-        eta = max(min(eta, etamax), stop_tol/res_norm)
+        eta = max(min(eta, etamax), stop_tol / res_norm)
         if fl == 1:
-            print('%3d\t%6d\t%.3e' % (i, k, res_norm), flush=True)
+            print("%3d\t%6d\t%.3e" % (i, k, res_norm), flush=True)
         res.append(res_norm)
 
-        print('Matrix-vector products = %6d' % (MVP,), flush=True)
+        print("Matrix-vector products = %6d" % (MVP,), flush=True)
 
     x_full = np.zeros(len(mask))
     x_full[mask] = x

--- a/cooltools/cli/__init__.py
+++ b/cooltools/cli/__init__.py
@@ -10,40 +10,38 @@ click.core._verify_python3_env = lambda: None
 
 
 CONTEXT_SETTINGS = {
-    'help_option_names': ['-h', '--help'],
+    "help_option_names": ["-h", "--help"],
 }
 
 
 @click.version_option(version=__version__)
 @click.group(context_settings=CONTEXT_SETTINGS)
+@click.option("--debug/--no-debug", help="Verbose logging", default=False)
 @click.option(
-    '--debug/--no-debug',
-    help="Verbose logging",
-    default=False)
-@click.option(
-    '-pm', '--post-mortem',
-    help="Post mortem debugging",
-    is_flag=True,
-    default=False)
+    "-pm", "--post-mortem", help="Post mortem debugging", is_flag=True, default=False
+)
 def cli(debug, post_mortem):
     """
     Type -h or --help after any subcommand for more information.
 
     """
     if debug:
-    	pass
-        #logger.setLevel(logging.DEBUG)
+        pass
+        # logger.setLevel(logging.DEBUG)
 
     if post_mortem:
         import traceback
+
         try:
             import ipdb as pdb
         except ImportError:
             import pdb
+
         def _excepthook(exc_type, value, tb):
             traceback.print_exception(exc_type, value, tb)
             print()
             pdb.pm()
+
         sys.excepthook = _excepthook
 
 
@@ -55,5 +53,5 @@ from . import (
     call_dots,
     call_compartments,
     genome,
-    random_sample
+    random_sample,
 )

--- a/cooltools/cli/__init__.py
+++ b/cooltools/cli/__init__.py
@@ -14,22 +14,30 @@ CONTEXT_SETTINGS = {
 }
 
 
-@click.version_option(version=__version__)
+@click.version_option(__version__, "-V", "--version")
 @click.group(context_settings=CONTEXT_SETTINGS)
-@click.option("--debug/--no-debug", help="Verbose logging", default=False)
 @click.option(
-    "-pm", "--post-mortem", help="Post mortem debugging", is_flag=True, default=False
+    "-v", "--verbose",
+    help="Verbose logging",
+    is_flag=True,
+    default=False
 )
-def cli(debug, post_mortem):
+@click.option(
+    "-d", "--debug",
+    help="Post mortem debugging",
+    is_flag=True,
+    default=False
+)
+def cli(verbose, debug):
     """
     Type -h or --help after any subcommand for more information.
 
     """
-    if debug:
+    if verbose:
         pass
         # logger.setLevel(logging.DEBUG)
 
-    if post_mortem:
+    if debug:
         import traceback
 
         try:

--- a/cooltools/cli/call_compartments.py
+++ b/cooltools/cli/call_compartments.py
@@ -11,42 +11,44 @@ from . import cli
 
 
 @cli.command()
-@click.argument(
-    "cool_path",
-    metavar="COOL_PATH",
-    type=str)
+@click.argument("cool_path", metavar="COOL_PATH", type=str)
 @click.option(
     "--reference-track",
     help="Reference track for orienting and ranking eigenvectors",
-    type=TabularFilePath(exists=True, default_column_index=3))
+    type=TabularFilePath(exists=True, default_column_index=3),
+)
 @click.option(
-    '--contact-type',
+    "--contact-type",
     help="Type of the contacts perform eigen-value decomposition on.",
-    type=click.Choice(['cis', 'trans']),
-    default='cis',
-    show_default=True)
+    type=click.Choice(["cis", "trans"]),
+    default="cis",
+    show_default=True,
+)
 @click.option(
-    '--n-eigs',
+    "--n-eigs",
     help="Number of eigenvectors to compute.",
     type=int,
     default=3,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    "--verbose", "-v",
-    help="Enable verbose output",
-    is_flag=True,
-    default=False)
+    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+)
 @click.option(
-    "--out-prefix", "-o",
+    "--out-prefix",
+    "-o",
     help="Save compartment track as a BED-like file.",
-    required=True)
+    required=True,
+)
 @click.option(
     "--bigwig",
     help="Also save compartment track as a bigWig file.",
     is_flag=True,
-    default=False)
-def call_compartments(cool_path, reference_track, contact_type, n_eigs,
-                      verbose, out_prefix, bigwig):
+    default=False,
+)
+def call_compartments(
+    cool_path, reference_track, contact_type, n_eigs, verbose, out_prefix, bigwig
+):
     """
     Perform eigen value decomposition on a cooler matrix to calculate
     compartment signal by finding the eigenvector that correlates best with the
@@ -74,14 +76,16 @@ def call_compartments(cool_path, reference_track, contact_type, n_eigs,
         if names is None:
             if not isinstance(col, int):
                 raise click.BadParameter(
-                    'No header found. '
-                    'Cannot find "{}" column without a header.'.format(col))
+                    "No header found. "
+                    'Cannot find "{}" column without a header.'.format(col)
+                )
 
-            track_name = 'ref'
+            track_name = "ref"
             kwargs = dict(
                 header=None,
                 usecols=[0, 1, 2, col],
-                names=['chrom', 'start', 'end', track_name])
+                names=["chrom", "start", "end", track_name],
+            )
         else:
             if isinstance(col, int):
                 try:
@@ -89,27 +93,29 @@ def call_compartments(cool_path, reference_track, contact_type, n_eigs,
                 except IndexError:
                     raise click.BadParameter(
                         'Column #{} not compatible with header "{}".'.format(
-                            col, ','.join(names)))
+                            col, ",".join(names)
+                        )
+                    )
             else:
                 if col not in names:
                     raise click.BadParameter(
                         'Column "{}" not found in header "{}"'.format(
-                            col, ','.join(names)))
+                            col, ",".join(names)
+                        )
+                    )
 
             track_name = col
-            kwargs = dict(
-                header='infer',
-                usecols=['chrom', 'start', 'end', track_name])
+            kwargs = dict(header="infer", usecols=["chrom", "start", "end", track_name])
 
         track_df = pd.read_table(
             buf,
             dtype={
-                'chrom': str,
-                'start': np.int64,
-                'end': np.int64,
+                "chrom": str,
+                "start": np.int64,
+                "end": np.int64,
                 track_name: np.float64,
             },
-            comment='#',
+            comment="#",
             verbose=verbose,
             **kwargs
         )
@@ -118,20 +124,19 @@ def call_compartments(cool_path, reference_track, contact_type, n_eigs,
         # a DataFrame with phasing info aligned and validated against bins inside of
         # the cooler file.
         track = pd.merge(
-            left=clr.bins()[:],
-            right=track_df,
-            how="left",
-            on=["chrom", "start", "end"])
+            left=clr.bins()[:], right=track_df, how="left", on=["chrom", "start", "end"]
+        )
 
         # sanity check would be to check if len(bins) becomes > than nbins ...
         # that would imply there was something in the track_df that didn't match
         # ["chrom", "start", "end"] - keys from the c.bins()[:] .
         if len(track) > len(clr.bins()):
             ValueError(
-                "There is something in the {} that ".format(track_path) +
-                "couldn't be merged with cooler-bins {}".format(cool_path))
+                "There is something in the {} that ".format(track_path)
+                + "couldn't be merged with cooler-bins {}".format(cool_path)
+            )
     else:
-        track = clr.bins()[['chrom', 'start', 'end']][:]
+        track = clr.bins()[["chrom", "start", "end"]][:]
         track_name = None
 
     # it's contact_type dependent:
@@ -143,7 +148,8 @@ def call_compartments(cool_path, reference_track, contact_type, n_eigs,
             n_eigs=n_eigs,
             phasing_track_col=track_name,
             clip_percentile=99.9,
-            sort_metric=None)
+            sort_metric=None,
+        )
     elif contact_type == "trans":
         eigvals, eigvec_table = eigdecomp.cooler_trans_eig(
             clr=clr,
@@ -151,14 +157,18 @@ def call_compartments(cool_path, reference_track, contact_type, n_eigs,
             n_eigs=n_eigs,
             partition=None,
             phasing_track_col=track_name,
-            sort_metric=None)
+            sort_metric=None,
+        )
 
     # Output
-    eigvals.to_csv(out_prefix + '.' + contact_type + '.lam.txt', sep='\t', index=False)
-    eigvec_table.to_csv(out_prefix + '.' + contact_type + '.vecs.tsv', sep='\t', index=False)
+    eigvals.to_csv(out_prefix + "." + contact_type + ".lam.txt", sep="\t", index=False)
+    eigvec_table.to_csv(
+        out_prefix + "." + contact_type + ".vecs.tsv", sep="\t", index=False
+    )
     if bigwig:
         bioframe.to_bigwig(
             eigvec_table,
             clr.chromsizes,
-            out_prefix + '.' + contact_type + '.bw',
-            value_field='E1')
+            out_prefix + "." + contact_type + ".bw",
+            value_field="E1",
+        )

--- a/cooltools/cli/call_compartments.py
+++ b/cooltools/cli/call_compartments.py
@@ -1,4 +1,3 @@
-from functools import partial
 import pandas as pd
 import numpy as np
 import cooler
@@ -11,7 +10,11 @@ from . import cli
 
 
 @cli.command()
-@click.argument("cool_path", metavar="COOL_PATH", type=str)
+@click.argument(
+    "cool_path",
+    metavar="COOL_PATH",
+    type=str
+)
 @click.option(
     "--reference-track",
     help="Reference track for orienting and ranking eigenvectors",
@@ -32,11 +35,13 @@ from . import cli
     show_default=True,
 )
 @click.option(
-    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+    "-v", "--verbose",
+    help="Enable verbose output",
+    is_flag=True,
+    default=False
 )
 @click.option(
-    "--out-prefix",
-    "-o",
+    "-o", "--out-prefix",
     help="Save compartment track as a BED-like file.",
     required=True,
 )

--- a/cooltools/cli/call_dots.py
+++ b/cooltools/cli/call_dots.py
@@ -10,163 +10,179 @@ from . import cli
 from .. import dotfinder
 
 
-
 @cli.command()
 @click.argument(
     "cool_path",
     metavar="COOL_PATH",
-    type=str, #click.Path(exists=True, dir_okay=False),
-    nargs=1)
+    type=str,  # click.Path(exists=True, dir_okay=False),
+    nargs=1,
+)
 @click.argument(
     "expected_path",
     metavar="EXPECTED_PATH",
     type=click.Path(exists=True, dir_okay=False),
-    nargs=1)
+    nargs=1,
+)
 @click.option(
-    '--expected-name',
+    "--expected-name",
     help="Name of value column in EXPECTED_PATH",
     type=str,
-    default='balanced.avg',
+    default="balanced.avg",
     show_default=True,
-    )
+)
 @click.option(
-    '--balancing-weight-name',
+    "--balancing-weight-name",
     help="Use balancing weight with this name.",
     type=str,
-    default='weight',
-    show_default=True)
+    default="weight",
+    show_default=True,
+)
 @click.option(
-    '--nproc', '-n',
+    "--nproc",
+    "-n",
     help="Number of processes to split the work between."
-         " [default: 1, i.e. no process pool]",
+    " [default: 1, i.e. no process pool]",
     default=1,
-    type=int)
+    type=int,
+)
 @click.option(
-    '--max-loci-separation',
-    help='Limit loci separation for dot-calling, i.e., do not call dots for'
-         ' loci that are further than max_loci_separation basepair apart.'
-         ' 2-20MB is reasonable and would capture most of CTCF-dots.',
+    "--max-loci-separation",
+    help="Limit loci separation for dot-calling, i.e., do not call dots for"
+    " loci that are further than max_loci_separation basepair apart."
+    " 2-20MB is reasonable and would capture most of CTCF-dots.",
     type=int,
     default=2000000,
     show_default=True,
-    )
+)
 @click.option(
-    '--max-nans-tolerated',
-    help='Maximum number of NaNs tolerated in a footprint of every used filter.'
-         ' Must be controlled with caution, as large max-nans-tolerated, might lead to'
-         ' pixels scored in the padding area of the tiles to "penetrate" to the list'
-         ' of scored pixels for the statistical testing. [max-nans-tolerated <= 2*w ]',
+    "--max-nans-tolerated",
+    help="Maximum number of NaNs tolerated in a footprint of every used filter."
+    " Must be controlled with caution, as large max-nans-tolerated, might lead to"
+    ' pixels scored in the padding area of the tiles to "penetrate" to the list'
+    " of scored pixels for the statistical testing. [max-nans-tolerated <= 2*w ]",
     type=int,
     default=1,
     show_default=True,
-    )
+)
 @click.option(
-    '--tile-size',
-    help='Tile size for the Hi-C heatmap tiling.'
-         ' Typically on order of several mega-bases, and <= max_loci_separation.',
+    "--tile-size",
+    help="Tile size for the Hi-C heatmap tiling."
+    " Typically on order of several mega-bases, and <= max_loci_separation.",
     type=int,
     default=6000000,
     show_default=True,
-    )
+)
 @click.option(
-    '--kernel-width',
+    "--kernel-width",
     help="Outer half-width of the convolution kernel in pixels"
-         " e.g. outer size (w) of the 'donut' kernel, with the 2*w+1"
-         " overall footprint of the 'donut'.",
-    type=int)
+    " e.g. outer size (w) of the 'donut' kernel, with the 2*w+1"
+    " overall footprint of the 'donut'.",
+    type=int,
+)
 @click.option(
-    '--kernel-peak',
+    "--kernel-peak",
     help="Inner half-width of the convolution kernel in pixels"
-         " e.g. inner size (p) of the 'donut' kernel, with the 2*p+1"
-         " overall footprint of the punch-hole.",
-    type=int)
+    " e.g. inner size (p) of the 'donut' kernel, with the 2*p+1"
+    " overall footprint of the punch-hole.",
+    type=int,
+)
 @click.option(
-    '--num-lambda-chunks',
+    "--num-lambda-chunks",
     help="Number of log-spaced bins to divide your adjusted expected"
-         " between. Same as HiCCUPS_W1_MAX_INDX in the original HiCCUPS.",
+    " between. Same as HiCCUPS_W1_MAX_INDX in the original HiCCUPS.",
     type=int,
     default=45,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
     "--fdr",
     help="False discovery rate (FDR) to control in the multiple"
-         " hypothesis testing BH-FDR procedure.",
+    " hypothesis testing BH-FDR procedure.",
     type=float,
     default=0.02,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    '--dots-clustering-radius',
-    help='Radius for clustering dots that have been called too close to each other.'
-         'Typically on order of 40 kilo-bases, and >= binsize.',
+    "--dots-clustering-radius",
+    help="Radius for clustering dots that have been called too close to each other."
+    "Typically on order of 40 kilo-bases, and >= binsize.",
     type=int,
     default=39000,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    "--verbose", "-v",
-    help="Enable verbose output",
-    is_flag=True,
-    default=False)
+    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+)
 @click.option(
-    "--output-scores", "-s",
+    "--output-scores",
+    "-s",
     help="At the moment it is a redundant option that"
-         " does nothing. Reserve it for a better dump"
-         " of convolved scores.",
+    " does nothing. Reserve it for a better dump"
+    " of convolved scores.",
     type=str,
-    required=False)
+    required=False,
+)
 @click.option(
     "--output-hists",
     help="Specify output file name to store"
-         " lambda-chunked histograms. [Not implemented yet]",
+    " lambda-chunked histograms. [Not implemented yet]",
     type=str,
-    required=False)
+    required=False,
+)
 @click.option(
-    "--output-calls", "-o",
+    "--output-calls",
+    "-o",
     help="Specify output file name where to store"
-         " the results of dot-calling, in a BEDPE format."
-         " Pre-processed dots are stored in that file."
-         " Post-processed dots are stored in the .postproc one.",
-    type=str)
+    " the results of dot-calling, in a BEDPE format."
+    " Pre-processed dots are stored in that file."
+    " Post-processed dots are stored in the .postproc one.",
+    type=str,
+)
 @click.option(
     "--score-dump-mode",
     help="Specify file format for the dump of convolved scores."
-         " This dump is used for the downstream processing and"
-         " is read twice. Now 'parquet' is the only supported"
-         " format. 'cooler' and 'hdf' in the future.",
+    " This dump is used for the downstream processing and"
+    " is read twice. Now 'parquet' is the only supported"
+    " format. 'cooler' and 'hdf' in the future.",
     type=str,
     default="parquet",
-    show_default=True)
+    show_default=True,
+)
 @click.option(
     "--temp-dir",
     help="Create temporary files in specified directory.",
     type=str,
-    default='.',
-    show_default=True)
+    default=".",
+    show_default=True,
+)
 @click.option(
     "--no-delete-temp",
     help="Do not delete temporary files when finished.",
     is_flag=True,
-    default=False)
+    default=False,
+)
 def call_dots(
-        cool_path,
-        expected_path,
-        expected_name,
-        balancing_weight_name,
-        nproc,
-        max_loci_separation,
-        max_nans_tolerated,
-        tile_size,
-        kernel_width,
-        kernel_peak,
-        num_lambda_chunks,
-        fdr,
-        dots_clustering_radius,
-        verbose,
-        output_scores,
-        output_hists,
-        output_calls,
-        score_dump_mode,
-        temp_dir,
-        no_delete_temp):
+    cool_path,
+    expected_path,
+    expected_name,
+    balancing_weight_name,
+    nproc,
+    max_loci_separation,
+    max_nans_tolerated,
+    tile_size,
+    kernel_width,
+    kernel_peak,
+    num_lambda_chunks,
+    fdr,
+    dots_clustering_radius,
+    verbose,
+    output_scores,
+    output_hists,
+    output_calls,
+    score_dump_mode,
+    temp_dir,
+    no_delete_temp,
+):
     """
     Call dots on a Hi-C heatmap that are not larger than max_loci_separation.
 
@@ -189,22 +205,22 @@ def call_dots(
     """
     clr = cooler.Cooler(cool_path)
 
-    expected_columns = ['chrom', 'diag', 'n_valid', expected_name]
-    expected_index = ['chrom', 'diag']
+    expected_columns = ["chrom", "diag", "n_valid", expected_name]
+    expected_index = ["chrom", "diag"]
     expected_dtypes = {
-        'chrom': np.str,
-        'diag': np.int64,
-        'n_valid': np.int64,
-        expected_name: np.float64
+        "chrom": np.str,
+        "diag": np.int64,
+        "n_valid": np.int64,
+        expected_name: np.float64,
     }
     expected = pd.read_table(
         expected_path,
         usecols=expected_columns,
         dtype=expected_dtypes,
         comment=None,
-        verbose=verbose)
-    expected.set_index(expected_index,inplace=True)
-
+        verbose=verbose,
+    )
+    expected.set_index(expected_index, inplace=True)
 
     # Input validation
     # unique list of chroms mentioned in expected_path
@@ -213,55 +229,61 @@ def call_dots(
     expected_chroms = get_exp_chroms(expected)
     if not set(expected_chroms).issubset(clr.chromnames):
         raise ValueError(
-            "Chromosomes in {} must be subset of ".format(expected_path) +
-            "chromosomes in cooler {}".format(cool_path))
+            "Chromosomes in {} must be subset of ".format(expected_path)
+            + "chromosomes in cooler {}".format(cool_path)
+        )
     # check number of bins
     # compute # of bins by comparing matching indexes
     get_exp_bins = lambda df, ref_chroms: (
-        df.index.get_level_values("chrom").isin(ref_chroms).sum())
+        df.index.get_level_values("chrom").isin(ref_chroms).sum()
+    )
     expected_bins = get_exp_bins(expected, expected_chroms)
     cool_bins = clr.bins()[:]["chrom"].isin(expected_chroms).sum()
     if not (expected_bins == cool_bins):
         raise ValueError(
             "Number of bins is not matching: ",
             "{} in {}, and {} in {} for chromosomes {}".format(
-                expected_bins,
-                expected_path,
-                cool_bins,
-                cool_path,
-                expected_chroms))
+                expected_bins, expected_path, cool_bins, cool_path, expected_chroms
+            ),
+        )
     if verbose:
-        print("{} and {} passed cross-compatibility checks.".format(
-            cool_path, expected_path))
-
+        print(
+            "{} and {} passed cross-compatibility checks.".format(
+                cool_path, expected_path
+            )
+        )
 
     # Prepare some parameters.
     binsize = clr.binsize
     loci_separation_bins = int(max_loci_separation / binsize)
     tile_size_bins = int(tile_size / binsize)
-    balance_factor = 1.0  #clr._load_attrs("bins/weight")["scale"]
+    balance_factor = 1.0  # clr._load_attrs("bins/weight")["scale"]
 
     # clustering would deal with bases-units for now, so supress this for now
     # clustering_radius_bins = int(dots_clustering_radius/binsize)
 
     # kernels
     # 'upright' is a symmetrical inversion of "lowleft", not needed.
-    ktypes = ['donut', 'vertical', 'horizontal', 'lowleft']
+    ktypes = ["donut", "vertical", "horizontal", "lowleft"]
 
     if (kernel_width is None) or (kernel_peak is None):
-        w,p = dotfinder.recommend_kernel_params(binsize)
-        print( "Using kernel parameters w={}, p={} recommended for binsize {}".format(w,p,binsize) )
+        w, p = dotfinder.recommend_kernel_params(binsize)
+        print(
+            "Using kernel parameters w={}, p={} recommended for binsize {}".format(
+                w, p, binsize
+            )
+        )
     else:
-        w,p = kernel_width, kernel_peak
+        w, p = kernel_width, kernel_peak
         # add some sanity check for w,p:
-        assert w > p, "Wrong inner/outer kernel parameters w={}, p={}".format(w,p)
-        print( "Using kernel parameters w={}, p={} provided by user".format(w,p) )
+        assert w > p, "Wrong inner/outer kernel parameters w={}, p={}".format(w, p)
+        print("Using kernel parameters w={}, p={} provided by user".format(w, p))
 
     # once kernel parameters are setup check max_nans_tolerated
     # to make sure kernel footprints overlaping 1 side with the
     # NaNs filled row/column are not "allowed"
     # this requires dynamic adjustment for the "shrinking donut"
-    assert max_nans_tolerated <= 2*w, "Too many NaNs allowed!"
+    assert max_nans_tolerated <= 2 * w, "Too many NaNs allowed!"
     # may lead to scoring the same pixel twice, - i.e. duplicates.
 
     # generate standard kernels - consider providing custom ones
@@ -270,69 +292,78 @@ def call_dots(
     # list of tile coordinate ranges
     tiles = list(
         dotfinder.heatmap_tiles_generator_diag(
-            clr,
-            expected_chroms,
-            w,
-            tile_size_bins,
-            loci_separation_bins
+            clr, expected_chroms, w, tile_size_bins, loci_separation_bins
         )
     )
 
-    
     # lambda-chunking edges ...
     assert dotfinder.HiCCUPS_W1_MAX_INDX <= num_lambda_chunks <= 50
-    base = 2 ** (1/3)
-    ledges = np.concatenate((
-        [-np.inf],
-        np.logspace(0, num_lambda_chunks - 1, num=num_lambda_chunks, base=base, dtype=np.float),
-        [np.inf]))
-
+    base = 2 ** (1 / 3)
+    ledges = np.concatenate(
+        (
+            [-np.inf],
+            np.logspace(
+                0,
+                num_lambda_chunks - 1,
+                num=num_lambda_chunks,
+                base=base,
+                dtype=np.float,
+            ),
+            [np.inf],
+        )
+    )
 
     # 1. Calculate genome-wide histograms of scores.
-    gw_hist = dotfinder.scoring_and_histogramming_step(clr,
-                                            expected,
-                                            expected_name,
-                                            balancing_weight_name,
-                                            tiles,
-                                            kernels,
-                                            ledges,
-                                            max_nans_tolerated,
-                                            loci_separation_bins,
-                                            nproc,
-                                            verbose)
+    gw_hist = dotfinder.scoring_and_histogramming_step(
+        clr,
+        expected,
+        expected_name,
+        balancing_weight_name,
+        tiles,
+        kernels,
+        ledges,
+        max_nans_tolerated,
+        loci_separation_bins,
+        nproc,
+        verbose,
+    )
 
     if verbose:
         print("Done building histograms ...")
 
     # 2. Determine the FDR thresholds.
     threshold_df, qvalues = dotfinder.determine_thresholds(
-        kernels, ledges, gw_hist, fdr)
-
+        kernels, ledges, gw_hist, fdr
+    )
 
     # 3. Filter using FDR thresholds calculated in the histogramming step
-    filtered_pixels = dotfinder.scoring_and_extraction_step(clr,
-                                            expected,
-                                            expected_name,
-                                            balancing_weight_name,
-                                            tiles,
-                                            kernels,
-                                            ledges,
-                                            threshold_df,
-                                            max_nans_tolerated,
-                                            balance_factor,
-                                            loci_separation_bins,
-                                            output_calls,
-                                            nproc,
-                                            verbose)
+    filtered_pixels = dotfinder.scoring_and_extraction_step(
+        clr,
+        expected,
+        expected_name,
+        balancing_weight_name,
+        tiles,
+        kernels,
+        ledges,
+        threshold_df,
+        max_nans_tolerated,
+        balance_factor,
+        loci_separation_bins,
+        output_calls,
+        nproc,
+        verbose,
+    )
 
     # 4. Post-processing
     if verbose:
-        print("Begin post-processing of {} filtered pixels".format(len(filtered_pixels)))
+        print(
+            "Begin post-processing of {} filtered pixels".format(len(filtered_pixels))
+        )
         print("preparing to extract needed q-values ...")
 
-    filtered_pixels_qvals = dotfinder.annotate_pixels_with_qvalues(filtered_pixels,
-                                                                    qvalues,
-                                                                    kernels)
+    filtered_pixels_qvals = dotfinder.annotate_pixels_with_qvalues(
+        filtered_pixels, qvalues, kernels
+    )
     # 4a. clustering
     ########################################################################
     # Clustering has to be done using annotated DataFrame of filtered pixels
@@ -340,27 +371,19 @@ def call_dots(
     ########################################################################
     filtered_pixels_annotated = cooler.annotate(filtered_pixels_qvals, clr.bins()[:])
     centroids = dotfinder.clustering_step(
-                                filtered_pixels_annotated,
-                                expected_chroms,
-                                dots_clustering_radius,
-                                verbose)
+        filtered_pixels_annotated, expected_chroms, dots_clustering_radius, verbose
+    )
 
     # 4b. filter by enrichment and qval
     postprocessed_calls = dotfinder.thresholding_step(centroids)
-
 
     # Final-postprocessed result
     if output_calls is not None:
 
         postprocessed_fname = op.join(
-            op.dirname(output_calls),
-            op.basename(output_calls)+".postproc")
+            op.dirname(output_calls), op.basename(output_calls) + ".postproc"
+        )
 
         postprocessed_calls.to_csv(
-            postprocessed_fname,
-            sep='\t',
-            header=True,
-            index=False,
-            compression=None)
-
-
+            postprocessed_fname, sep="\t", header=True, index=False, compression=None
+        )

--- a/cooltools/cli/call_dots.py
+++ b/cooltools/cli/call_dots.py
@@ -1,9 +1,7 @@
 import os.path as op
-from scipy.stats import poisson
 import pandas as pd
 import numpy as np
 import cooler
-import tempfile
 
 import click
 from . import cli
@@ -38,8 +36,7 @@ from .. import dotfinder
     show_default=True,
 )
 @click.option(
-    "--nproc",
-    "-n",
+    "-n", "--nproc",
     help="Number of processes to split the work between."
     " [default: 1, i.e. no process pool]",
     default=1,
@@ -111,11 +108,11 @@ from .. import dotfinder
     show_default=True,
 )
 @click.option(
-    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+    "-v", "--verbose",
+    help="Enable verbose output", is_flag=True, default=False
 )
 @click.option(
-    "--output-scores",
-    "-s",
+    "-s", "--output-scores",
     help="At the moment it is a redundant option that"
     " does nothing. Reserve it for a better dump"
     " of convolved scores.",
@@ -130,8 +127,7 @@ from .. import dotfinder
     required=False,
 )
 @click.option(
-    "--output-calls",
-    "-o",
+    "-o", "--output-calls",
     help="Specify output file name where to store"
     " the results of dot-calling, in a BEDPE format."
     " Pre-processed dots are stored in that file."

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -1,5 +1,4 @@
 import multiprocess as mp
-import numpy as np
 import pandas as pd
 import cooler
 from .. import expected
@@ -15,37 +14,33 @@ from . import cli
 @cli.command()
 @click.argument("cool_path", metavar="COOL_PATH", type=str, nargs=1)
 @click.option(
-    "--nproc",
-    "-p",
+    "-p", "--nproc",
     help="Number of processes to split the work between."
     "[default: 1, i.e. no process pool]",
     default=1,
     type=int,
 )
 @click.option(
-    "--chunksize",
-    "-c",
+    "-c", "--chunksize",
     help="Control the number of pixels handled by each worker process at a time.",
     type=int,
     default=int(10e6),
     show_default=True,
 )
 @click.option(
-    "--output",
-    "-o",
-    help="Specify output file name to store" " the expected in a tsv format.",
+    "-o", "--output",
+    help="Specify output file name to store the expected in a tsv format.",
     type=str,
     required=False,
 )
 @click.option(
     "--hdf",
-    help="Use hdf5 format instead of tsv." " Output file name must be specified.",
+    help="Use hdf5 format instead of tsv. Output file name must be specified.",
     is_flag=True,
     default=False,
 )
 @click.option(
-    "--contact-type",
-    "-t",
+    "-t", "--contact-type",
     help="compute expected for cis or trans region" "of a Hi-C map.",
     type=click.Choice(["cis", "trans"]),
     default="cis",

--- a/cooltools/cli/compute_expected.py
+++ b/cooltools/cli/compute_expected.py
@@ -11,56 +11,60 @@ from . import cli
 # https://stackoverflow.com/questions/46577535/how-can-i-run-a-dask-distributed-local-cluster-from-the-command-line
 # http://distributed.readthedocs.io/en/latest/setup.html#using-the-command-line
 
+
 @cli.command()
-@click.argument(
-    "cool_path",
-    metavar="COOL_PATH",
-    type=str,
-    nargs=1)
+@click.argument("cool_path", metavar="COOL_PATH", type=str, nargs=1)
 @click.option(
-    '--nproc', '-p',
+    "--nproc",
+    "-p",
     help="Number of processes to split the work between."
-         "[default: 1, i.e. no process pool]",
+    "[default: 1, i.e. no process pool]",
     default=1,
-    type=int)
+    type=int,
+)
 @click.option(
-    "--chunksize", "-c",
+    "--chunksize",
+    "-c",
     help="Control the number of pixels handled by each worker process at a time.",
     type=int,
     default=int(10e6),
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    "--output", "-o",
-    help="Specify output file name to store"
-         " the expected in a tsv format.",
+    "--output",
+    "-o",
+    help="Specify output file name to store" " the expected in a tsv format.",
     type=str,
-    required=False)
+    required=False,
+)
 @click.option(
     "--hdf",
-    help="Use hdf5 format instead of tsv."
-         " Output file name must be specified.",
+    help="Use hdf5 format instead of tsv." " Output file name must be specified.",
     is_flag=True,
-    default=False)
+    default=False,
+)
 @click.option(
-    '--contact-type', "-t",
-    help="compute expected for cis or trans region"
-    "of a Hi-C map.",
-    type=click.Choice(['cis', 'trans']),
-    default='cis',
+    "--contact-type",
+    "-t",
+    help="compute expected for cis or trans region" "of a Hi-C map.",
+    type=click.Choice(["cis", "trans"]),
+    default="cis",
     show_default=True,
-    )
+)
 @click.option(
-    '--weight-name',
+    "--weight-name",
     help="Use balancing weight with this name.",
     type=str,
-    default='weight',
-    show_default=True)
+    default="weight",
+    show_default=True,
+)
 @click.option(
     "--drop-diags",
     help="Number of diagonals to neglect for cis contact type",
     type=int,
     default=2,
-    show_default=True)
+    show_default=True,
+)
 # can we use feature switch
 # for --cis/--trans instead (?):
 # http://click.pocoo.org/options/#feature-switches
@@ -81,7 +85,9 @@ from . import cli
 #     flag_value='trans',
 #     required=True
 #     )
-def compute_expected(cool_path, nproc, chunksize, output, hdf, contact_type, weight_name, drop_diags):
+def compute_expected(
+    cool_path, nproc, chunksize, output, hdf, contact_type, weight_name, drop_diags
+):
     """
     Calculate expected Hi-C signal either for cis or for trans regions
     of chromosomal interaction map.
@@ -91,8 +97,8 @@ def compute_expected(cool_path, nproc, chunksize, output, hdf, contact_type, wei
     """
     clr = cooler.Cooler(cool_path)
     supports = [(chrom, 0, clr.chromsizes[chrom]) for chrom in clr.chromnames]
-    weight1 = weight_name+"1"
-    weight2 = weight_name+"2"
+    weight1 = weight_name + "1"
+    weight2 = weight_name + "2"
 
     if nproc > 1:
         pool = mp.Pool(nproc)
@@ -101,48 +107,49 @@ def compute_expected(cool_path, nproc, chunksize, output, hdf, contact_type, wei
         map_ = map
 
     try:
-        if contact_type == 'cis':
+        if contact_type == "cis":
             tables = expected.diagsum(
                 clr,
                 supports,
-                transforms={
-                    'balanced': lambda p: p['count'] * p[weight1] * p[weight2]
-                },
+                transforms={"balanced": lambda p: p["count"] * p[weight1] * p[weight2]},
                 chunksize=chunksize,
                 ignore_diags=drop_diags,
-                map=map_)
+                map=map_,
+            )
             result = pd.concat(
                 [tables[support] for support in supports],
                 keys=[support[0] for support in supports],
-                names=['chrom'])
-            result['balanced.avg'] = result['balanced.sum'] / result['n_valid']
+                names=["chrom"],
+            )
+            result["balanced.avg"] = result["balanced.sum"] / result["n_valid"]
             result = result.reset_index()
 
-        elif contact_type == 'trans':
+        elif contact_type == "trans":
             records = expected.blocksum_pairwise(
                 clr,
                 supports,
-                transforms={
-                    'balanced': lambda p: p['count'] * p[weight1] * p[weight2]
-                },
+                transforms={"balanced": lambda p: p["count"] * p[weight1] * p[weight2]},
                 chunksize=chunksize,
-                map=map_)
+                map=map_,
+            )
             result = pd.DataFrame(
-                [{'chrom1': s1[0], 'chrom2': s2[0], **rec}
-                    for (s1, s2), rec in records.items()],
-                columns=['chrom1', 'chrom2', 'n_valid',
-                         'count.sum', 'balanced.sum'])
-            result['balanced.avg'] = result['balanced.sum'] / result['n_valid']
+                [
+                    {"chrom1": s1[0], "chrom2": s2[0], **rec}
+                    for (s1, s2), rec in records.items()
+                ],
+                columns=["chrom1", "chrom2", "n_valid", "count.sum", "balanced.sum"],
+            )
+            result["balanced.avg"] = result["balanced.sum"] / result["n_valid"]
     finally:
         if nproc > 1:
             pool.close()
 
     # output to file if specified:
     if output:
-        result.to_csv(output,sep='\t', index=False, na_rep='nan')
+        result.to_csv(output, sep="\t", index=False, na_rep="nan")
     # or print into stdout otherwise:
     else:
-        print(result.to_csv(sep='\t', index=False, na_rep='nan'))
+        print(result.to_csv(sep="\t", index=False, na_rep="nan"))
 
     # would be nice to have some binary output to preserve precision.
     # to_hdf/read_hdf should work in this case as the file is small .

--- a/cooltools/cli/compute_saddle.py
+++ b/cooltools/cli/compute_saddle.py
@@ -17,128 +17,152 @@ from . import cli
 
 @cli.command()
 @click.argument(
-    "cool_path",
-    metavar="COOL_PATH",
-    type=str) #click.Path(exists=True, dir_okay=False),)
+    "cool_path", metavar="COOL_PATH", type=str
+)  # click.Path(exists=True, dir_okay=False),)
 @click.argument(
     "track_path",
     metavar="TRACK_PATH",
     type=str,
-    callback=partial(validate_csv, default_column='E1'))
+    callback=partial(validate_csv, default_column="E1"),
+)
 @click.argument(
     "expected_path",
     metavar="EXPECTED_PATH",
     type=str,
-    callback=partial(validate_csv, default_column='balanced.avg'))
+    callback=partial(validate_csv, default_column="balanced.avg"),
+)
 @click.option(
-    '--contact-type', "-t",
+    "--contact-type",
+    "-t",
     help="Type of the contacts to aggregate",
-    type=click.Choice(['cis', 'trans']),
-    default='cis',
-    show_default=True)
+    type=click.Choice(["cis", "trans"]),
+    default="cis",
+    show_default=True,
+)
 @click.option(
     "--min-dist",
     help="Minimal distance between bins to consider, bp. If negative, removes"
-         "the first two diagonals of the data. Ignored with --contact-type trans.",
+    "the first two diagonals of the data. Ignored with --contact-type trans.",
     type=int,
     default=-1,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
     "--max-dist",
     help="Maximal distance between bins to consider, bp. Ignored, if negative."
-         " Ignored with --contact-type trans.",
+    " Ignored with --contact-type trans.",
     type=int,
     default=-1,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    "--n-bins", "-n",
+    "--n-bins",
+    "-n",
     help="Number of bins for digitizing track values.",
     type=int,
     default=50,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
     "--quantiles",
     help="Bin the signal track into quantiles rather than by value.",
     is_flag=True,
-    default=False)
+    default=False,
+)
 @click.option(
-    '--range',
-    'range_',
+    "--range",
+    "range_",
     help="Low and high values used for binning genome-wide track values, e.g. "
-         "if `range`=(-0.05, 0.05), `n-bins` equidistant bins would be generated. "
-         "Use to prevent the extreme track values from exploding the bin range and "
-         "to ensure consistent bins across several runs of `compute_saddle` command "
-         "using different track files.",
+    "if `range`=(-0.05, 0.05), `n-bins` equidistant bins would be generated. "
+    "Use to prevent the extreme track values from exploding the bin range and "
+    "to ensure consistent bins across several runs of `compute_saddle` command "
+    "using different track files.",
     nargs=2,
-    type=float)
+    type=float,
+)
 @click.option(
-    '--qrange',
+    "--qrange",
     help="The fraction of the genome-wide range of the track values used to "
-         "generate bins. E.g., if `qrange`=(0.02, 0.98) the lower bin would "
-         "start at the 2nd percentile and the upper bin would end at the 98th "
-         "percentile of the genome-wide signal. "
-         "Use to prevent the extreme track values from exploding the bin range.",
+    "generate bins. E.g., if `qrange`=(0.02, 0.98) the lower bin would "
+    "start at the 2nd percentile and the upper bin would end at the 98th "
+    "percentile of the genome-wide signal. "
+    "Use to prevent the extreme track values from exploding the bin range.",
     type=(float, float),
     default=(0.0, 1.0),
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    '--weight-name',
+    "--weight-name",
     help="Use balancing weight with this name.",
     type=str,
-    default='weight',
-    show_default=True)
+    default="weight",
+    show_default=True,
+)
 @click.option(
     "--strength/--no-strength",
     help="Compute and save compartment 'saddle strength' profile",
     is_flag=True,
-    default=False)
+    default=False,
+)
 @click.option(
-    "--out-prefix", "-o",
+    "--out-prefix",
+    "-o",
     help="Dump 'saddledata', 'binedges' and 'hist' arrays in a numpy-specific "
-         ".npz container. Use numpy.load to load these arrays into a "
-         "dict-like object. The digitized signal values are saved to a "
-         "bedGraph-style TSV.",
-    required=True)
+    ".npz container. Use numpy.load to load these arrays into a "
+    "dict-like object. The digitized signal values are saved to a "
+    "bedGraph-style TSV.",
+    required=True,
+)
 @click.option(
     "--fig",
-    type=click.Choice(['png', 'jpg', 'svg', 'pdf', 'ps', 'eps']),
+    type=click.Choice(["png", "jpg", "svg", "pdf", "ps", "eps"]),
     multiple=True,
     help="Generate a figure and save to a file of the specified format. "
-         "If not specified - no image is generated. Repeat for multiple "
-         "output formats.")
+    "If not specified - no image is generated. Repeat for multiple "
+    "output formats.",
+)
 @click.option(
-    '--scale',
+    "--scale",
     help="Value scale for the heatmap",
-    type=click.Choice(['linear', 'log']),
-    default='log',
-    show_default=True)
+    type=click.Choice(["linear", "log"]),
+    default="log",
+    show_default=True,
+)
 @click.option(
-    '--cmap',
-    help="Name of matplotlib colormap",
-    default='coolwarm',
-    show_default=True)
+    "--cmap", help="Name of matplotlib colormap", default="coolwarm", show_default=True
+)
 @click.option(
-    '--vmin',
-    help="Low value of the saddleplot colorbar",
-    type=float,
-    default=0.5)
+    "--vmin", help="Low value of the saddleplot colorbar", type=float, default=0.5
+)
 @click.option(
-    '--vmax',
-    help="High value of the saddleplot colorbar",
-    type=float,
-    default=2)
+    "--vmax", help="High value of the saddleplot colorbar", type=float, default=2
+)
+@click.option("--hist-color", help="Face color of histogram bar chart")
 @click.option(
-    '--hist-color',
-    help="Face color of histogram bar chart")
-@click.option(
-    "--verbose", "-v",
-    help="Enable verbose output",
-    is_flag=True,
-    default=False)
-def compute_saddle(cool_path, track_path, expected_path, contact_type,
-                   min_dist, max_dist, n_bins, quantiles, range_, qrange,
-                   weight_name, strength, out_prefix, fig, scale, cmap,
-                   vmin, vmax, hist_color, verbose):
+    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+)
+def compute_saddle(
+    cool_path,
+    track_path,
+    expected_path,
+    contact_type,
+    min_dist,
+    max_dist,
+    n_bins,
+    quantiles,
+    range_,
+    qrange,
+    weight_name,
+    strength,
+    out_prefix,
+    fig,
+    scale,
+    cmap,
+    vmin,
+    vmax,
+    hist_color,
+    verbose,
+):
     """
     Calculate saddle statistics and generate saddle plots for an arbitrary
     signal track on the genomic bins of a contact matrix.
@@ -174,52 +198,54 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
     # it's contact_type dependent:
     if contact_type == "cis":
         # that's what we expect as column names:
-        expected_columns = ['chrom', 'diag', 'n_valid', expected_name]
+        expected_columns = ["chrom", "diag", "n_valid", expected_name]
         # what would become a MultiIndex:
-        expected_index = ['chrom', 'diag']
+        expected_index = ["chrom", "diag"]
         # expected dtype as a rudimentary form of validation:
         expected_dtype = {
-            'chrom': np.str,
-            'diag': np.int64,
-            'n_valid': np.int64,
-            expected_name: np.float64
+            "chrom": np.str,
+            "diag": np.int64,
+            "n_valid": np.int64,
+            expected_name: np.float64,
         }
         # unique list of chroms mentioned in expected_path:
         get_exp_chroms = lambda df: df.index.get_level_values("chrom").unique()
         # compute # of bins by comparing matching indexes:
-        get_exp_bins   = lambda df, ref_chroms, _: (
+        get_exp_bins = lambda df, ref_chroms, _: (
             df.index.get_level_values("chrom").isin(ref_chroms).sum()
         )
     elif contact_type == "trans":
         # that's what we expect as column names:
-        expected_columns = ['chrom1', 'chrom2', 'n_valid', expected_name]
+        expected_columns = ["chrom1", "chrom2", "n_valid", expected_name]
         # what would become a MultiIndex:
-        expected_index = ['chrom1', 'chrom2']
+        expected_index = ["chrom1", "chrom2"]
         # expected dtype as a rudimentary form of validation:
         expected_dtype = {
-            'chrom1': np.str,
-            'chrom2': np.str,
-            'n_valid': np.int64,
-            expected_name: np.float64
+            "chrom1": np.str,
+            "chrom2": np.str,
+            "n_valid": np.int64,
+            expected_name: np.float64,
         }
         # unique list of chroms mentioned in expected_path:
         get_exp_chroms = lambda df: np.union1d(
             df.index.get_level_values("chrom1").unique(),
-            df.index.get_level_values("chrom2").unique())
+            df.index.get_level_values("chrom2").unique(),
+        )
         # no way to get bins from trans-expected, so just get the number:
-        get_exp_bins   = lambda _1,_2,correct_bins: correct_bins
+        get_exp_bins = lambda _1, _2, correct_bins: correct_bins
     else:
         raise ValueError(
             "Incorrect contact_type: {}, ".format(contact_type),
-            "Should have been caught by click.")
+            "Should have been caught by click.",
+        )
 
     if min_dist < 0:
         min_diag = 3
     else:
-        min_diag = int(np.ceil(min_dist/c.binsize))
+        min_diag = int(np.ceil(min_dist / c.binsize))
 
     if max_dist >= 0:
-        max_diag = int(np.floor(max_dist/c.binsize))
+        max_diag = int(np.floor(max_dist / c.binsize))
     else:
         max_diag = -1
 
@@ -232,56 +258,58 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
         index_col=expected_index,
         dtype=expected_dtype,
         comment=None,
-        verbose=False)
+        verbose=False,
+    )
 
     # read bedGraph-file :
-    track_columns = ['chrom', 'start', 'end', track_name]
+    track_columns = ["chrom", "start", "end", track_name]
     # specify dtype as a rudimentary form of validation:
     track_dtype = {
-        'chrom': np.str,
-        'start': np.int64,
-        'end': np.int64,
-        track_name: np.float64
+        "chrom": np.str,
+        "start": np.int64,
+        "end": np.int64,
+        track_name: np.float64,
     }
     track = pd.read_table(
         track_path,
         usecols=track_columns,
         dtype=track_dtype,
         comment=None,
-        verbose=False)
+        verbose=False,
+    )
 
     #############################################
     # CROSS-VALIDATE COOLER, EXPECTED AND TRACK:
     #############################################
     # TRACK vs COOLER:
-    track_chroms = track['chrom'].unique()
+    track_chroms = track["chrom"].unique()
     # We might want to try this eventually:
     # https://github.com/TMiguelT/PandasSchema
     # do simple column-name validation for now:
     if not set(track_chroms).issubset(c.chromnames):
         raise ValueError(
-            "Chromosomes in {} must be subset of ".format(track_path) +
-            "chromosomes in cooler {}".format(cool_path))
+            "Chromosomes in {} must be subset of ".format(track_path)
+            + "chromosomes in cooler {}".format(cool_path)
+        )
     # check number of bins:
     track_bins = len(track)
-    cool_bins   = c.bins()[:]["chrom"].isin(track_chroms).sum()
+    cool_bins = c.bins()[:]["chrom"].isin(track_chroms).sum()
     if not (track_bins == cool_bins):
         raise ValueError(
             "Number of bins is not matching: ",
             "{} in {}, and {} in {} for chromosomes {}".format(
-                track_bins,
-                track_path,
-                cool_bins,
-                cool_path,
-                track_chroms))
+                track_bins, track_path, cool_bins, cool_path, track_chroms
+            ),
+        )
     # EXPECTED vs TRACK:
     # validate expected a bit as well:
     expected_chroms = get_exp_chroms(expected)
     # do simple column-name validation for now:
     if not set(track_chroms).issubset(expected_chroms):
         raise ValueError(
-            "Chromosomes in {} must be subset of ".format(track_path) +
-            "chromosomes in expected {}".format(expected_path))
+            "Chromosomes in {} must be subset of ".format(track_path)
+            + "chromosomes in expected {}".format(expected_path)
+        )
     # and again bins are supposed to match up:
     # only for cis though ...
     expected_bins = get_exp_bins(expected, track_chroms, track_bins)
@@ -289,11 +317,9 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
         raise ValueError(
             "Number of bins is not matching: ",
             "{} in {}, and {} in {} for chromosomes {}".format(
-                track_bins,
-                track_path,
-                expected_bins,
-                expected_path,
-                track_chroms))
+                track_bins, track_path, expected_bins, expected_path, track_chroms
+            ),
+        )
     #############################################
     # CROSS-VALIDATION IS COMPLETE.
     #############################################
@@ -301,11 +327,13 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
     track = saddle.mask_bad_bins((track, track_name), (c.bins()[:], weight_name))
 
     if contact_type == "cis":
-        getmatrix = saddle.make_cis_obsexp_fetcher(c, (expected, expected_name),
-                                                   weight_name=weight_name)
+        getmatrix = saddle.make_cis_obsexp_fetcher(
+            c, (expected, expected_name), weight_name=weight_name
+        )
     elif contact_type == "trans":
-        getmatrix = saddle.make_trans_obsexp_fetcher(c, (expected, expected_name),
-                                                     weight_name=weight_name)
+        getmatrix = saddle.make_trans_obsexp_fetcher(
+            c, (expected, expected_name), weight_name=weight_name
+        )
 
     if quantiles:
         if len(range_):
@@ -313,7 +341,7 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
         elif len(qrange):
             qlo, qhi = qrange
         else:
-            qlo, qhi = 0., 1.
+            qlo, qhi = 0.0, 1.0
         q_edges = np.linspace(qlo, qhi, n_bins)
         binedges = saddle.quantile(track[track_name], q_edges)
     else:
@@ -326,61 +354,58 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
         binedges = np.linspace(lo, hi, n_bins)
 
     digitized, hist = saddle.digitize_track(
-        binedges,
-        track=(track, track_name),
-        regions=track_chroms)
+        binedges, track=(track, track_name), regions=track_chroms
+    )
 
     S, C = saddle.make_saddle(
         getmatrix,
         binedges,
-        (digitized, track_name + '.d'),
+        (digitized, track_name + ".d"),
         contact_type=contact_type,
         min_diag=min_diag,
-        max_diag=max_diag)
+        max_diag=max_diag,
+    )
 
     saddledata = S / C
 
-    to_save = dict(
-        saddledata=saddledata,
-        binedges=binedges,
-        hist=hist)
+    to_save = dict(saddledata=saddledata, binedges=binedges, hist=hist)
 
     if strength:
         ratios = saddle.saddle_strength(S, C)
         ratios = ratios[1:-1]  # drop outlier bins
-        to_save['saddle_strength'] = ratios
+        to_save["saddle_strength"] = ratios
 
     # Save data
-    np.savez(
-        out_prefix + ".saddledump",  # .npz auto-added
-        **to_save)
-    digitized.to_csv(
-        out_prefix + '.digitized.tsv',
-        sep='\t',
-        index=False)
+    np.savez(out_prefix + ".saddledump", **to_save)  # .npz auto-added
+    digitized.to_csv(out_prefix + ".digitized.tsv", sep="\t", index=False)
 
     # Generate figure
     if len(fig):
         try:
             import matplotlib as mpl
-            mpl.use('Agg')  # savefig only for now:
+
+            mpl.use("Agg")  # savefig only for now:
             import matplotlib.pyplot as plt
         except ImportError:
             print("Install matplotlib to use ", file=sys.stderr)
             sys.exit(1)
 
         if hist_color is None:
-            color = (0.41568627450980394, 0.8, 0.39215686274509803) #sns.color_palette('muted')[2]
+            color = (
+                0.41568627450980394,
+                0.8,
+                0.39215686274509803,
+            )  # sns.color_palette('muted')[2]
         else:
             color = mpl.colors.colorConverter.to_rgb(hist_color)
-        title = op.basename(cool_path) + ' ({})'.format(contact_type)
+        title = op.basename(cool_path) + " ({})".format(contact_type)
         if quantiles:
             edges = q_edges
-            track_label = track_name + ' quantiles'
+            track_label = track_name + " quantiles"
         else:
             edges = binedges
             track_label = track_name
-        clabel = '(contact frequency / expected)'
+        clabel = "(contact frequency / expected)"
 
         saddle.saddleplot(
             edges,
@@ -393,8 +418,8 @@ def compute_saddle(cool_path, track_path, expected_path, contact_type,
             title=title,
             xlabel=track_label,
             ylabel=track_label,
-            clabel=clabel)
+            clabel=clabel,
+        )
 
         for ext in fig:
-            plt.savefig(out_prefix + '.' + ext, bbox_inches='tight')
-
+            plt.savefig(out_prefix + "." + ext, bbox_inches="tight")

--- a/cooltools/cli/compute_saddle.py
+++ b/cooltools/cli/compute_saddle.py
@@ -4,7 +4,6 @@
 from functools import partial
 import os.path as op
 import sys
-from scipy.linalg import toeplitz
 import pandas as pd
 import numpy as np
 import cooler
@@ -17,7 +16,9 @@ from . import cli
 
 @cli.command()
 @click.argument(
-    "cool_path", metavar="COOL_PATH", type=str
+    "cool_path",
+    metavar="COOL_PATH",
+    type=str
 )  # click.Path(exists=True, dir_okay=False),)
 @click.argument(
     "track_path",
@@ -32,8 +33,7 @@ from . import cli
     callback=partial(validate_csv, default_column="balanced.avg"),
 )
 @click.option(
-    "--contact-type",
-    "-t",
+    "-t", "--contact-type",
     help="Type of the contacts to aggregate",
     type=click.Choice(["cis", "trans"]),
     default="cis",
@@ -56,8 +56,7 @@ from . import cli
     show_default=True,
 )
 @click.option(
-    "--n-bins",
-    "-n",
+    "-n", "--n-bins",
     help="Number of bins for digitizing track values.",
     type=int,
     default=50,
@@ -105,8 +104,7 @@ from . import cli
     default=False,
 )
 @click.option(
-    "--out-prefix",
-    "-o",
+    "-o", "--out-prefix",
     help="Dump 'saddledata', 'binedges' and 'hist' arrays in a numpy-specific "
     ".npz container. Use numpy.load to load these arrays into a "
     "dict-like object. The digitized signal values are saved to a "
@@ -129,17 +127,32 @@ from . import cli
     show_default=True,
 )
 @click.option(
-    "--cmap", help="Name of matplotlib colormap", default="coolwarm", show_default=True
+    "--cmap",
+    help="Name of matplotlib colormap",
+    default="coolwarm",
+    show_default=True
 )
 @click.option(
-    "--vmin", help="Low value of the saddleplot colorbar", type=float, default=0.5
+    "--vmin",
+    help="Low value of the saddleplot colorbar",
+    type=float,
+    default=0.5
 )
 @click.option(
-    "--vmax", help="High value of the saddleplot colorbar", type=float, default=2
+    "--vmax",
+    help="High value of the saddleplot colorbar",
+    type=float,
+    default=2
 )
-@click.option("--hist-color", help="Face color of histogram bar chart")
 @click.option(
-    "--verbose", "-v", help="Enable verbose output", is_flag=True, default=False
+    "--hist-color",
+    help="Face color of histogram bar chart"
+)
+@click.option(
+    "-v", "--verbose",
+    help="Enable verbose output",
+    is_flag=True,
+    default=False
 )
 def compute_saddle(
     cool_path,

--- a/cooltools/cli/diamond_insulation.py
+++ b/cooltools/cli/diamond_insulation.py
@@ -5,55 +5,56 @@ import cooler
 from . import cli
 from .. import insulation
 
+
 @cli.command()
-@click.argument(
-    "in_path",
-    metavar="IN_PATH",
-    type=str,
-    nargs=1)
-@click.argument(
-    'window',
-    nargs=-1,
-    metavar="WINDOW",
-    type=int)
+@click.argument("in_path", metavar="IN_PATH", type=str, nargs=1)
+@click.argument("window", nargs=-1, metavar="WINDOW", type=int)
 @click.option(
-    '--ignore-diags',
-    help='The number of diagonals to ignore. By default, equals'
-        ' the number of diagonals ignored during IC balancing.',
+    "--ignore-diags",
+    help="The number of diagonals to ignore. By default, equals"
+    " the number of diagonals ignored during IC balancing.",
     type=int,
     default=None,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    '--min-frac-valid-pixels',
-    help='The minimal fraction of valid pixels in a sliding diamond. '
-         'Used to mask bins during boundary detection.',
+    "--min-frac-valid-pixels",
+    help="The minimal fraction of valid pixels in a sliding diamond. "
+    "Used to mask bins during boundary detection.",
     type=float,
     default=0.66,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    '--min-dist-bad-bin',
-    help='The minimal allowed distance to a bad bin. '
-         'Used to mask bins during boundary detection.',
+    "--min-dist-bad-bin",
+    help="The minimal allowed distance to a bad bin. "
+    "Used to mask bins during boundary detection.",
     type=int,
     default=0,
-    show_default=True)
+    show_default=True,
+)
 @click.option(
-    '--window-pixels',
-    help='If set then the window sizes are provided in units of pixels.',
-    is_flag=True)
+    "--window-pixels",
+    help="If set then the window sizes are provided in units of pixels.",
+    is_flag=True,
+)
 @click.option(
-    '--append-raw-scores',
-    help='Append columns with raw scores (sum_counts, sum_balanced, n_pixels) '
-         'to the output table.',
-    is_flag=True)
-@click.option(
-    '--verbose',
-    help='Report real-time progress.',
-    is_flag=True)
-
-
-def diamond_insulation(in_path, window, ignore_diags, min_frac_valid_pixels, 
-                       min_dist_bad_bin, window_pixels, append_raw_scores, verbose):
+    "--append-raw-scores",
+    help="Append columns with raw scores (sum_counts, sum_balanced, n_pixels) "
+    "to the output table.",
+    is_flag=True,
+)
+@click.option("--verbose", help="Report real-time progress.", is_flag=True)
+def diamond_insulation(
+    in_path,
+    window,
+    ignore_diags,
+    min_frac_valid_pixels,
+    min_dist_bad_bin,
+    window_pixels,
+    append_raw_scores,
+    verbose,
+):
     """
     Calculate the diamond insulation scores and call insulating boundaries.
 
@@ -68,23 +69,20 @@ def diamond_insulation(in_path, window, ignore_diags, min_frac_valid_pixels,
 
     clr = cooler.Cooler(in_path)
     if window_pixels:
-        window = [win*clr.info['bin-size'] for win in window]
-    
-    
+        window = [win * clr.info["bin-size"] for win in window]
+
     ins_table = insulation.calculate_insulation_score(
         clr,
         window_bp=window,
         ignore_diags=ignore_diags,
         append_raw_scores=append_raw_scores,
-        verbose=verbose)
-    
-    
+        verbose=verbose,
+    )
+
     ins_table = insulation.find_boundaries(
         ins_table,
         min_frac_valid_pixels=min_frac_valid_pixels,
         min_dist_bad_bin=min_dist_bad_bin,
     )
 
-
-    print(ins_table.to_csv(sep='\t', index=False, na_rep='nan'))
-
+    print(ins_table.to_csv(sep="\t", index=False, na_rep="nan"))

--- a/cooltools/cli/diamond_insulation.py
+++ b/cooltools/cli/diamond_insulation.py
@@ -1,5 +1,4 @@
 import click
-
 import cooler
 
 from . import cli
@@ -7,8 +6,18 @@ from .. import insulation
 
 
 @cli.command()
-@click.argument("in_path", metavar="IN_PATH", type=str, nargs=1)
-@click.argument("window", nargs=-1, metavar="WINDOW", type=int)
+@click.argument(
+    "in_path",
+    metavar="IN_PATH",
+    type=str,
+    nargs=1
+)
+@click.argument(
+    "window",
+    nargs=-1,
+    metavar="WINDOW",
+    type=int
+)
 @click.option(
     "--ignore-diags",
     help="The number of diagonals to ignore. By default, equals"
@@ -44,7 +53,11 @@ from .. import insulation
     "to the output table.",
     is_flag=True,
 )
-@click.option("--verbose", help="Report real-time progress.", is_flag=True)
+@click.option(
+    "--verbose",
+    help="Report real-time progress.",
+    is_flag=True
+)
 def diamond_insulation(
     in_path,
     window,
@@ -60,7 +73,7 @@ def diamond_insulation(
 
     IN_PATH : The paths to a .cool file with a balanced Hi-C map.
 
-    WINDOW : The window size for the insulation score calculations. 
+    WINDOW : The window size for the insulation score calculations.
              Multiple space-separated values can be provided.
              By default, the window size must be provided in units of bp.
              When the flag --window-pixels is set, the window sizes must

--- a/cooltools/cli/dump_cworld.py
+++ b/cooltools/cli/dump_cworld.py
@@ -4,75 +4,67 @@ from .. import io
 
 
 @cli.command()
-@click.argument(
-    "cool_paths",
-    metavar="COOL_PATHS",
-    type=str,
-    nargs=-1)
+@click.argument("cool_paths", metavar="COOL_PATHS", type=str, nargs=-1)
 @click.argument(
     "out_path",
     metavar="OUT_PATH",
-    type=click.Path(
-        exists=False,
-        writable=True),
-    nargs=1)
+    type=click.Path(exists=False, writable=True),
+    nargs=1,
+)
 @click.option(
-    '--cworld-type',
+    "--cworld-type",
     help="The format of the CWorld output. "
     "'matrix' converts a single .cool file into the .matrix.txt.gz tab-separated format. "
     "'tar' dumps all specified cooler files into a "
     "single .tar archive containing multiple .matrix.txt.gz files (use to make "
     "multi-resolution archives).",
-    type=click.Choice(['matrix', 'tar']),
-    default='matrix',
+    type=click.Choice(["matrix", "tar"]),
+    default="matrix",
     show_default=True,
-    )
+)
 @click.option(
-    '--region',
+    "--region",
     help="The coordinates of a genomic region to dump, in the UCSC format. "
     "If empty (by default), dump a genome-wide matrix. This option can be used "
     "only when dumping a single cooler file.",
     type=str,
-    default='',
+    default="",
     show_default=True,
-    )
+)
 @click.option(
-    '--balancing-type',
+    "--balancing-type",
     help="The type of the matrix balancing. 'IC_unity' - iteratively corrected "
     "for the total number of contacts per locus=1.0; 'IC' - same, but preserving "
     "the average total number of contacts; 'raw' - no balancing",
-    type=click.Choice(['IC_unity', 'IC', 'raw']),
-    default='IC_unity',
+    type=click.Choice(["IC_unity", "IC", "raw"]),
+    default="IC_unity",
     show_default=True,
-    )
-
-def dump_cworld(cool_paths, out_path, cworld_type, region,balancing_type):
+)
+def dump_cworld(cool_paths, out_path, cworld_type, region, balancing_type):
     """
     Convert a cooler or a group of coolers into the Dekker' lab CWorld text format.
 
     COOL_PATHS : Paths to one or multiple .cool files
     OUT_PATH : Output CWorld file path
     """
-    if (cworld_type == 'matrix') and (len(cool_paths) > 1):
-            raise click.ClickException(
-                'Only one .cool file can be converted into the matrix '
-                'format at a time.')
+    if (cworld_type == "matrix") and (len(cool_paths) > 1):
+        raise click.ClickException(
+            "Only one .cool file can be converted into the matrix " "format at a time."
+        )
 
-    if (cworld_type == 'matrix'):
+    if cworld_type == "matrix":
         io.dump_cworld(
             cool_paths[0],
             out_path,
             region=region,
-            iced=(balancing_type != 'raw'),
-            iced_unity=(balancing_type=='IC_unity'),
-            buffer_size=int(1e8)
-            )
-    elif (cworld_type == 'tar'):
+            iced=(balancing_type != "raw"),
+            iced_unity=(balancing_type == "IC_unity"),
+            buffer_size=int(1e8),
+        )
+    elif cworld_type == "tar":
         if region:
             raise Exception(
-                'Only genome-wide matrices and not specific regions can be dumpled'
-                ' into a .tar CWorld archive.')
-        io.dump_cworld_tar(
-            cool_paths,
-            out_path
+                "Only genome-wide matrices and not specific regions can be dumpled"
+                " into a .tar CWorld archive."
             )
+        io.dump_cworld_tar(cool_paths, out_path)

--- a/cooltools/cli/dump_cworld.py
+++ b/cooltools/cli/dump_cworld.py
@@ -4,7 +4,12 @@ from .. import io
 
 
 @cli.command()
-@click.argument("cool_paths", metavar="COOL_PATHS", type=str, nargs=-1)
+@click.argument(
+    "cool_paths",
+    metavar="COOL_PATHS",
+    type=str,
+    nargs=-1
+)
 @click.argument(
     "out_path",
     metavar="OUT_PATH",

--- a/cooltools/cli/genome.py
+++ b/cooltools/cli/genome.py
@@ -12,77 +12,72 @@ def genome():
 
 
 @genome.command()
-@click.argument(
-    "db")
+@click.argument("db")
 def fetch_chromsizes(db):
     import bioframe
+
     chromsizes = bioframe.fetch_chromsizes(db)
-    print(chromsizes.to_csv(sep='\t'))
+    print(chromsizes.to_csv(sep="\t"))
 
 
 @genome.command()
-@click.argument(
-    "chromsizes_path")
-@click.argument(
-    "binsize",
-    type=int)
+@click.argument("chromsizes_path")
+@click.argument("binsize", type=int)
 def binnify(chromsizes_path, binsize):
     import bioframe
+
     chromsizes = bioframe.read_chromsizes(chromsizes_path)
     bins = bioframe.tools.binnify(chromsizes, binsize)
-    print(bins.to_csv(sep='\t', index=False))
+    print(bins.to_csv(sep="\t", index=False))
 
 
 @genome.command()
-@click.argument(
-    "chromsizes_path")
-@click.argument(
-    "fasta_path")
-@click.argument(
-    "enzyme_name")
+@click.argument("chromsizes_path")
+@click.argument("fasta_path")
+@click.argument("enzyme_name")
 def digest(chromsizes_path, fasta_path, enzyme_name):
     import bioframe
+
     chromsizes = bioframe.read_chromsizes(chromsizes_path, all_names=True)
-    fasta_records = bioframe.load_fasta(fasta_path, engine='pyfaidx', as_raw=True)
+    fasta_records = bioframe.load_fasta(fasta_path, engine="pyfaidx", as_raw=True)
     if not chromsizes.index.isin(fasta_records).all():
-        raise ValueError("Some chromosomes mentioned in {}"
-                         " are not found in {}".format(chromsizes_path, fasta_path))
+        raise ValueError(
+            "Some chromosomes mentioned in {}"
+            " are not found in {}".format(chromsizes_path, fasta_path)
+        )
     frags = bioframe.tools.digest(fasta_records, enzyme_name)
-    print(frags.to_csv(sep='\t', index=False))
+    print(frags.to_csv(sep="\t", index=False))
 
 
 @genome.command()
-@click.argument(
-    "bins_path")
-@click.argument(
-    "fasta_path")
-@click.option(
-    "--mapped-only",
-    is_flag=True,
-    default=True)
+@click.argument("bins_path")
+@click.argument("fasta_path")
+@click.option("--mapped-only", is_flag=True, default=True)
 def gc(bins_path, fasta_path, mapped_only):
     import bioframe
     import pandas as pd
-    if bins_path == '-':
+
+    if bins_path == "-":
         bins_path = sys.stdin
     bins = pd.read_table(bins_path)
-    chromosomes = bins['chrom'].unique()
-    fasta_records = bioframe.load_fasta(fasta_path, engine='pyfaidx', as_raw=True)
+    chromosomes = bins["chrom"].unique()
+    fasta_records = bioframe.load_fasta(fasta_path, engine="pyfaidx", as_raw=True)
     if any(chrom not in fasta_records.keys() for chrom in chromosomes):
-        raise ValueError("Some chromosomes mentioned in {}"
-                         " are not found in {}".format(bins_path, fasta_path))
-    bins['GC'] = bioframe.tools.frac_gc(bins, fasta_records, mapped_only)
-    print(bins.to_csv(sep='\t', index=False))
+        raise ValueError(
+            "Some chromosomes mentioned in {}"
+            " are not found in {}".format(bins_path, fasta_path)
+        )
+    bins["GC"] = bioframe.tools.frac_gc(bins, fasta_records, mapped_only)
+    print(bins.to_csv(sep="\t", index=False))
 
 
 @genome.command()
-@click.argument(
-    "bins_path")
-@click.argument(
-    "db")
+@click.argument("bins_path")
+@click.argument("db")
 def genecov(bins_path, db):
     import bioframe
     import pandas as pd
+
     bins = pd.read_table(bins_path)
     bins = bioframe.tools.frac_gene_coverage(bins, db)
-    print(bins.to_csv(sep='\t', index=False))
+    print(bins.to_csv(sep="\t", index=False))

--- a/cooltools/cli/random_sample.py
+++ b/cooltools/cli/random_sample.py
@@ -5,53 +5,42 @@ import cooler
 from . import cli
 from .. import sample
 
+
 @cli.command()
-@click.argument(
-    "in_path",
-    metavar="IN_PATH",
-    type=str,
-    nargs=1)
-
-@click.argument(
-    "out_path",
-    metavar="OUT_PATH",
-    type=str,
-    nargs=1)
-
+@click.argument("in_path", metavar="IN_PATH", type=str, nargs=1)
+@click.argument("out_path", metavar="OUT_PATH", type=str, nargs=1)
 @click.option(
-    '-c',
-    '--count',
-    help='The target number of contacts in the sample. '
-         'The resulting sample size will not match it precisely. '
-         'Mutually exclusive with --frac',
+    "-c",
+    "--count",
+    help="The target number of contacts in the sample. "
+    "The resulting sample size will not match it precisely. "
+    "Mutually exclusive with --frac",
     type=int,
     default=None,
-    show_default=False)
-
+    show_default=False,
+)
 @click.option(
-    '-f',
-    '--frac',
-    help='The target sample size as a fraction of contacts in the original dataset. '
-          'Mutually exclusive with --count',
+    "-f",
+    "--frac",
+    help="The target sample size as a fraction of contacts in the original dataset. "
+    "Mutually exclusive with --count",
     type=float,
     default=None,
-    show_default=False)
-
+    show_default=False,
+)
 @click.option(
-    '--exact',
-    help='If specified, use exact sampling that guarantees the size of the output sample. '
-         'Otherwise, binomial sampling will be used and the sample size will be distributed around the target value. ',
+    "--exact",
+    help="If specified, use exact sampling that guarantees the size of the output sample. "
+    "Otherwise, binomial sampling will be used and the sample size will be distributed around the target value. ",
     is_flag=True,
 )
-
 @click.option(
-    '--chunksize',
-    help='The number of pixels loaded and processed per step of computation.',
+    "--chunksize",
+    help="The number of pixels loaded and processed per step of computation.",
     type=int,
     default=int(1e7),
-    show_default=True)
-
-
+    show_default=True,
+)
 def random_sample(in_path, out_path, count, frac, exact, chunksize):
     """
     Pick a random sample of contacts from a Hi-C map, w/o replacement.
@@ -63,7 +52,13 @@ def random_sample(in_path, out_path, count, frac, exact, chunksize):
     Specify the target sample size with either --count or --frac.
 
     """
-    
-    sample.sample_cooler(in_path, out_path, count=count, 
-                     frac=frac, exact=exact, chunksize=chunksize, map_func=map)
-    
+
+    sample.sample_cooler(
+        in_path,
+        out_path,
+        count=count,
+        frac=frac,
+        exact=exact,
+        chunksize=chunksize,
+        map_func=map,
+    )

--- a/cooltools/cli/util.py
+++ b/cooltools/cli/util.py
@@ -5,7 +5,9 @@ import click
 
 
 class TabularFilePath(click.Path):
-    def __init__(self, default_column_index, exists=False, resolve_path=False, allow_dash=False):
+    def __init__(
+        self, default_column_index, exists=False, resolve_path=False, allow_dash=False
+    ):
         """
         Parameters
         ----------
@@ -20,13 +22,14 @@ class TabularFilePath(click.Path):
 
         """
         self.default_column_index = default_column_index
-        super().__init__(exists=exists,
-                         resolve_path=resolve_path,
-                         allow_dash=allow_dash)
+        super().__init__(
+            exists=exists, resolve_path=resolve_path, allow_dash=allow_dash
+        )
 
     def convert(self, value, param, ctx):
-        if value is None: return
-        file_path, _, field = value.partition('::')
+        if value is None:
+            return
+        file_path, _, field = value.partition("::")
         file_path = super().convert(file_path, param, ctx)
         if not field:
             col = self.default_column_index
@@ -39,12 +42,12 @@ class TabularFilePath(click.Path):
         return file_path, col
 
 
-def sniff_for_header(file_path, sep='\t', comment='#'):
+def sniff_for_header(file_path, sep="\t", comment="#"):
     """
     Warning: reads the entire file into a StringIO buffer!
 
     """
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         buf = io.StringIO(f.read())
 
     sample_lines = []
@@ -56,7 +59,7 @@ def sniff_for_header(file_path, sep='\t', comment='#'):
         sample_lines.append(buf.readline())
     buf.seek(0)
 
-    has_header = csv.Sniffer().has_header('\n'.join(sample_lines))
+    has_header = csv.Sniffer().has_header("\n".join(sample_lines))
     if has_header:
         names = sample_lines[0].strip().split(sep)
     else:
@@ -66,12 +69,13 @@ def sniff_for_header(file_path, sep='\t', comment='#'):
 
 
 def validate_csv(ctx, param, value, default_column):
-    if value is None: return
-    file_path, _, field_name = value.partition('::')
+    if value is None:
+        return
+    file_path, _, field_name = value.partition("::")
     if not op.exists(file_path):
         raise click.BadParameter(
-            'Path not found: "{}"'.format(file_path),
-            ctx=ctx, param=param)
+            'Path not found: "{}"'.format(file_path), ctx=ctx, param=param
+        )
     if not field_name:
         field_name = default_column
     elif field_name.isdigit():

--- a/cooltools/coverage.py
+++ b/cooltools/coverage.py
@@ -4,14 +4,14 @@ import cooler.tools
 
 def _zero_diags(chunk, n_diags):
     if n_diags > 0:
-        mask = np.abs(chunk['pixels']['bin1_id'] - chunk['pixels']['bin2_id']) < n_diags
-        chunk['pixels']['count'][mask] = 0
-    
+        mask = np.abs(chunk["pixels"]["bin1_id"] - chunk["pixels"]["bin2_id"]) < n_diags
+        chunk["pixels"]["count"][mask] = 0
+
     return chunk
 
 
-def _get_chunk_coverage(chunk, pixel_weight_key='count'):
-    '''
+def _get_chunk_coverage(chunk, pixel_weight_key="count"):
+    """
     Compute cis and total coverages of a cooler chunk.
     
     Parameters
@@ -25,33 +25,39 @@ def _get_chunk_coverage(chunk, pixel_weight_key='count'):
     -------
     covs : np.array 2 x n_bins    
         A numpy array with cis (the first row) and total (the 4nd) coverages.
-    '''
-    
-    bins = chunk['bins']
-    pixels = chunk['pixels']
-    n_bins = len(bins['chrom'])
+    """
+
+    bins = chunk["bins"]
+    pixels = chunk["pixels"]
+    n_bins = len(bins["chrom"])
     covs = np.zeros((2, n_bins))
     pixel_weights = pixels[pixel_weight_key]
-    
-    cis_mask = bins['chrom'][pixels['bin1_id']] == bins['chrom'][pixels['bin2_id']]
-    covs[0] += np.bincount(pixels['bin1_id'], weights=pixel_weights*cis_mask, minlength=n_bins)
-    covs[0] += np.bincount(pixels['bin2_id'], weights=pixel_weights*cis_mask, minlength=n_bins)
-    
-    covs[1] += np.bincount(pixels['bin1_id'], weights=pixel_weights, minlength=n_bins)
-    covs[1] += np.bincount(pixels['bin2_id'], weights=pixel_weights, minlength=n_bins)
-    
+
+    cis_mask = bins["chrom"][pixels["bin1_id"]] == bins["chrom"][pixels["bin2_id"]]
+    covs[0] += np.bincount(
+        pixels["bin1_id"], weights=pixel_weights * cis_mask, minlength=n_bins
+    )
+    covs[0] += np.bincount(
+        pixels["bin2_id"], weights=pixel_weights * cis_mask, minlength=n_bins
+    )
+
+    covs[1] += np.bincount(pixels["bin1_id"], weights=pixel_weights, minlength=n_bins)
+    covs[1] += np.bincount(pixels["bin2_id"], weights=pixel_weights, minlength=n_bins)
+
     covs = covs / 2
-    
+
     return covs
 
 
-def get_coverage(clr, 
-                 ignore_diags=None,
-                 chunksize=int(1e7), 
-                 map=map, 
-                 use_lock=False, 
-                 store=False, 
-                 store_names=['cis_raw_cov', 'tot_raw_cov']):
+def get_coverage(
+    clr,
+    ignore_diags=None,
+    chunksize=int(1e7),
+    map=map,
+    use_lock=False,
+    store=False,
+    store_names=["cis_raw_cov", "tot_raw_cov"],
+):
 
     """
     Calculate the sums of cis and genome-wide contacts (aka coverage aka marginals) for 
@@ -86,31 +92,30 @@ def get_coverage(clr,
     """
 
     try:
-        ignore_diags = (ignore_diags
-                        if ignore_diags is not None
-                        else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'])
+        ignore_diags = (
+            ignore_diags
+            if ignore_diags is not None
+            else clr._load_attrs(clr.root.rstrip("/") + "/bins/weight")["ignore_diags"]
+        )
     except:
-        raise ValueError('Please, specify ignore_diags and/or IC balance this cooler! Cannot access the value used in IC balancing. ')
-    
+        raise ValueError(
+            "Please, specify ignore_diags and/or IC balance this cooler! Cannot access the value used in IC balancing. "
+        )
+
     chunks = cooler.tools.split(clr, chunksize=chunksize, map=map, use_lock=use_lock)
-    
+
     if ignore_diags:
         chunks = chunks.pipe(_zero_diags, n_diags=ignore_diags)
-        
-    n_bins = clr.info['nbins']
-    covs = (
-        chunks
-            .pipe(_get_chunk_coverage)
-            .reduce(np.add, np.zeros((2, n_bins)))
-    )
+
+    n_bins = clr.info["nbins"]
+    covs = chunks.pipe(_get_chunk_coverage).reduce(np.add, np.zeros((2, n_bins)))
 
     if store:
-        with clr.open('r+') as grp:
+        with clr.open("r+") as grp:
             for store_name, cov_arr in zip(store_names, covs):
-                if store_name in grp['bins']:
-                    del grp['bins'][store_name]
-                h5opts = dict(compression='gzip', compression_opts=6)
-                grp['bins'].create_dataset(store_name, data=cov_arr, **h5opts)
+                if store_name in grp["bins"]:
+                    del grp["bins"][store_name]
+                h5opts = dict(compression="gzip", compression_opts=6)
+                grp["bins"].create_dataset(store_name, data=cov_arr, **h5opts)
 
     return covs
-

--- a/cooltools/directionality.py
+++ b/cooltools/directionality.py
@@ -4,23 +4,22 @@ import pandas as pd
 from .lib import peaks, numutils
 
 
-def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
-             signed_chi2=False):
+def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True, signed_chi2=False):
     lo_bin_id = bins.index.min()
     hi_bin_id = bins.index.max() + 1
     N = hi_bin_id - lo_bin_id
 
-    bad_bin_mask = bins['weight'].isnull(
-    ).values if balanced else np.zeros(N, dtype=bool)
+    bad_bin_mask = (
+        bins["weight"].isnull().values if balanced else np.zeros(N, dtype=bool)
+    )
 
-    diag_pixels = pixels[pixels['bin2_id'] -
-                         pixels['bin1_id'] <= (window - 1) * 2]
+    diag_pixels = pixels[pixels["bin2_id"] - pixels["bin1_id"] <= (window - 1) * 2]
     if balanced:
-        diag_pixels = diag_pixels[~diag_pixels['balanced'].isnull()]
+        diag_pixels = diag_pixels[~diag_pixels["balanced"].isnull()]
 
-    i = diag_pixels['bin1_id'].values - lo_bin_id
-    j = diag_pixels['bin2_id'].values - lo_bin_id
-    val = diag_pixels['balanced'].values if balanced else diag_pixels['count'].values
+    i = diag_pixels["bin1_id"].values - lo_bin_id
+    j = diag_pixels["bin2_id"].values - lo_bin_id
+    val = diag_pixels["balanced"].values if balanced else diag_pixels["count"].values
 
     sum_pixels_left = np.zeros(N)
     n_pixels_left = np.zeros(N)
@@ -28,12 +27,8 @@ def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
         if i_shift < ignore_diags:
             continue
 
-        mask = ((i + i_shift == j) &
-                (i + i_shift < N) &
-                (j >= 0))
-        sum_pixels_left += np.bincount(i[mask] + i_shift,
-                                       val[mask],
-                                       minlength=N)
+        mask = (i + i_shift == j) & (i + i_shift < N) & (j >= 0)
+        sum_pixels_left += np.bincount(i[mask] + i_shift, val[mask], minlength=N)
 
         loc_bad_bin_mask = np.zeros(N, dtype=bool)
         if i_shift == 0:
@@ -41,7 +36,7 @@ def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
         else:
             loc_bad_bin_mask[i_shift:] |= bad_bin_mask[:-i_shift]
             loc_bad_bin_mask |= bad_bin_mask
-        n_pixels_left[i_shift:] += (1 - loc_bad_bin_mask[i_shift:])
+        n_pixels_left[i_shift:] += 1 - loc_bad_bin_mask[i_shift:]
 
     sum_pixels_right = np.zeros(N)
     n_pixels_right = np.zeros(N)
@@ -49,14 +44,9 @@ def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
         if j_shift < ignore_diags:
             continue
 
-        mask = ((i == j - j_shift) &
-                (i < N) &
-                (j - j_shift >= 0))
+        mask = (i == j - j_shift) & (i < N) & (j - j_shift >= 0)
 
-        sum_pixels_right += np.bincount(
-            i[mask],
-            val[mask],
-            minlength=N)
+        sum_pixels_right += np.bincount(i[mask], val[mask], minlength=N)
 
         loc_bad_bin_mask = np.zeros(N, dtype=bool)
         loc_bad_bin_mask |= bad_bin_mask
@@ -65,8 +55,9 @@ def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
         else:
             loc_bad_bin_mask[:-j_shift] |= bad_bin_mask[j_shift:]
 
-        n_pixels_right[:(-j_shift if j_shift else None)] += (
-            1 - loc_bad_bin_mask[:(-j_shift if j_shift else None)])
+        n_pixels_right[: (-j_shift if j_shift else None)] += (
+            1 - loc_bad_bin_mask[: (-j_shift if j_shift else None)]
+        )
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -74,8 +65,8 @@ def dirscore(pixels, bins, window=10, ignore_diags=2, balanced=True,
         a = sum_pixels_left
         b = sum_pixels_right
         if signed_chi2:
-            e = (a + b)/2.0
-            score = np.sign(b - a) * ((a-e)**2 + (b-e)**2) / e
+            e = (a + b) / 2.0
+            score = np.sign(b - a) * ((a - e) ** 2 + (b - e) ** 2) / e
         else:
             score = (b - a) / (a + b)
 
@@ -86,13 +77,13 @@ def _dirscore_dense(A, window=10, signed_chi2=False):
     N = A.shape[0]
     di = np.zeros(N)
     for i in range(0, N):
-        lo = max(0, i-window)
-        hi = min((i+window)+1, N)
-        b, a = np.nansum(A[i, i:hi]), np.nansum(A[i, lo:i+1])
+        lo = max(0, i - window)
+        hi = min((i + window) + 1, N)
+        b, a = np.nansum(A[i, i:hi]), np.nansum(A[i, lo : i + 1])
         if signed_chi2:
-            e = (a + b)/2.0
+            e = (a + b) / 2.0
             if e:
-                di[i] = np.sign(b - a) * ((a-e)**2 + (b-e)**2) / e
+                di[i] = np.sign(b - a) * ((a - e) ** 2 + (b - e) ** 2) / e
         else:
             di[i] = (b - a) / (a + b)
     mask = np.nansum(A, axis=0) == 0
@@ -101,13 +92,14 @@ def _dirscore_dense(A, window=10, signed_chi2=False):
 
 
 def directionality(
-        clr,
-        window_bp=100000,
-        balance='weight',
-        min_dist_bad_bin=2,
-        ignore_diags=None,
-        chromosomes=None):
-    '''Calculate the diamond insulation scores and call insulating boundaries.
+    clr,
+    window_bp=100000,
+    balance="weight",
+    min_dist_bad_bin=2,
+    ignore_diags=None,
+    chromosomes=None,
+):
+    """Calculate the diamond insulation scores and call insulating boundaries.
 
     Parameters
     ----------
@@ -128,20 +120,24 @@ def directionality(
     ins_table : pandas.DataFrame
         A table containing the insulation scores of the genomic bins and
         the insulating boundary strengths.
-    '''
+    """
     if chromosomes is None:
         chromosomes = clr.chromnames
 
-    bin_size = clr.info['bin-size']
-    ignore_diags = (ignore_diags
-                    if ignore_diags is not None
-                    else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'])
+    bin_size = clr.info["bin-size"]
+    ignore_diags = (
+        ignore_diags
+        if ignore_diags is not None
+        else clr._load_attrs(clr.root.rstrip("/") + "/bins/weight")["ignore_diags"]
+    )
     window_bins = window_bp // bin_size
 
-    if (window_bp % bin_size != 0):
+    if window_bp % bin_size != 0:
         raise Exception(
-            'The window size ({}) has to be a multiple of the bin size {}'.format(
-                window_bp, bin_size))
+            "The window size ({}) has to be a multiple of the bin size {}".format(
+                window_bp, bin_size
+            )
+        )
 
     dir_chrom_tables = []
     for chrom in chromosomes:
@@ -149,42 +145,37 @@ def directionality(
         chrom_pixels = clr.matrix(as_pixels=True, balance=balance).fetch(chrom)
 
         # mask neighbors of bad bins
-        is_bad_bin = np.isnan(chrom_bins['weight'].values)
+        is_bad_bin = np.isnan(chrom_bins["weight"].values)
         bad_bin_neighbor = np.zeros_like(is_bad_bin)
         for i in range(0, min_dist_bad_bin):
             if i == 0:
                 bad_bin_neighbor = bad_bin_neighbor | is_bad_bin
             else:
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[
-                    [True]*i, is_bad_bin[:-i]]
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[
-                    is_bad_bin[i:], [True]*i]
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[[True] * i, is_bad_bin[:-i]]
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True] * i]
 
-        dir_chrom = chrom_bins[['chrom', 'start', 'end']].copy()
-        dir_chrom['bad_bin_masked'] = bad_bin_neighbor
+        dir_chrom = chrom_bins[["chrom", "start", "end"]].copy()
+        dir_chrom["bad_bin_masked"] = bad_bin_neighbor
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             dir_track = dirscore(
-                chrom_pixels,
-                chrom_bins,
-                window=window_bins,
-                ignore_diags=ignore_diags
+                chrom_pixels, chrom_bins, window=window_bins, ignore_diags=ignore_diags
             )
             dir_track[bad_bin_neighbor] = np.nan
             dir_track[~np.isfinite(dir_track)] = np.nan
-            dir_chrom['directionality_ratio_{}'.format(window_bp)] = dir_track
+            dir_chrom["directionality_ratio_{}".format(window_bp)] = dir_track
 
             dir_track = dirscore(
                 chrom_pixels,
                 chrom_bins,
                 window=window_bins,
                 ignore_diags=ignore_diags,
-                signed_chi2=True
+                signed_chi2=True,
             )
             dir_track[bad_bin_neighbor] = np.nan
             dir_track[~np.isfinite(dir_track)] = np.nan
-            dir_chrom['directionality_index_{}'.format(window_bp)] = dir_track
+            dir_chrom["directionality_index_{}".format(window_bp)] = dir_track
 
         dir_chrom_tables.append(dir_chrom)
 

--- a/cooltools/dotfinder.py
+++ b/cooltools/dotfinder.py
@@ -169,7 +169,7 @@ def annotate_pixels_with_qvalues(
     be too resource-hungry.
     """
     if inplace:
-        pixels_qvalue_df = pixel_df
+        pixels_qvalue_df = pixels_df
     else:
         # let's do it "safe" - using a copy:
         pixels_qvalue_df = pixels_df.copy()
@@ -1676,7 +1676,8 @@ def extraction_step(
             )
     finally:
         if nproc > 1:
-            pool.close()
+            # pool.close()
+            pass
     # there should be no duplicates in the "significant_pixels" DataFrame of pixels:
     significant_pixels_dups = significant_pixels.duplicated()
     assert (

--- a/cooltools/dotfinder.py
+++ b/cooltools/dotfinder.py
@@ -32,15 +32,16 @@ HiCCUPS_W2_MAX_INDX = 10000
 # this is to mitigate and parameterize the obs.raw vs count controversy:
 observed_count_name = "count"
 expected_count_name = "exp.raw"
-adjusted_exp_name = lambda kernel_name: "la_exp."+kernel_name+".value"
-nans_inkernel_name = lambda kernel_name: "la_exp."+kernel_name+".nnans"
-bin1_id_name='bin1_id'
-bin2_id_name='bin2_id'
+adjusted_exp_name = lambda kernel_name: "la_exp." + kernel_name + ".value"
+nans_inkernel_name = lambda kernel_name: "la_exp." + kernel_name + ".nnans"
+bin1_id_name = "bin1_id"
+bin2_id_name = "bin2_id"
 
 
 ##################################
 # generic service functions:
 ##################################
+
 
 def buffer_df_chunks(chunks, size=25000000):
     """
@@ -60,7 +61,11 @@ def buffer_df_chunks(chunks, size=25000000):
         n += len(chunk)
         buf.append(chunk)
         if n > size:
-            print("large chunk of size {} is ready, made up of {} chunks".format(n,len(buf)))
+            print(
+                "large chunk of size {} is ready, made up of {} chunks".format(
+                    n, len(buf)
+                )
+            )
             yield pd.concat(buf, axis=0)
             print("cleaning buffers ...")
             # reset buffer and counter:
@@ -68,13 +73,17 @@ def buffer_df_chunks(chunks, size=25000000):
             n = 0
     #  yield the remainder of the buffer:
     if len(buf):
-        print("LAST chunk of size {} is ready, made up of {} chunks".format(n,len(buf)))
+        print(
+            "LAST chunk of size {} is ready, made up of {} chunks".format(n, len(buf))
+        )
         yield pd.concat(buf, axis=0)
         print("last guy shipped ...")
+
 
 ##################################
 # dotfinder-specific service functions:
 ##################################
+
 
 def recommend_kernel_params(binsize):
     """
@@ -98,7 +107,8 @@ def recommend_kernel_params(binsize):
         # > 30 kb - is probably too much ...
         raise ValueError(
             "Provided cooler has resolution {} bases, "
-            "which is too coarse for analysis.".format(binsize))
+            "which is too coarse for analysis.".format(binsize)
+        )
     elif binsize >= 18000:
         # ~ 20-25 kb:
         w, p = 3, 1
@@ -112,11 +122,15 @@ def recommend_kernel_params(binsize):
         # < 5 kb - is probably too fine ...
         raise ValueError(
             "Provided cooler has resolution {} bases, "
-            "which is too fine for analysis.".format(binsize))
+            "which is too fine for analysis.".format(binsize)
+        )
     # return the results:
-    return w,p
+    return w, p
 
-def annotate_pixels_with_qvalues(pixels_df, qvalues, kernels, inplace=False, obs_raw_name = observed_count_name):
+
+def annotate_pixels_with_qvalues(
+    pixels_df, qvalues, kernels, inplace=False, obs_raw_name=observed_count_name
+):
     """
     Add columns with the qvalues to a DataFrame of pixels
     ... detailed but unedited notes ...
@@ -164,23 +178,29 @@ def annotate_pixels_with_qvalues(pixels_df, qvalues, kernels, inplace=False, obs
     # iteration over pairs of obs, la_exp and extracting needed qvals
     # one after another ...
     for k in kernels:
-        pixels_qvalue_df["la_exp."+k+".qval"] = \
-                [ qvalues[k].loc[o,e] for o,e \
-                     in pixels_df[[obs_raw_name,"la_exp."+k+".value"]].itertuples(index=False) ]
+        pixels_qvalue_df["la_exp." + k + ".qval"] = [
+            qvalues[k].loc[o, e]
+            for o, e in pixels_df[[obs_raw_name, "la_exp." + k + ".value"]].itertuples(
+                index=False
+            )
+        ]
     # qvalues : dict
     #   A dictionary with keys being kernel names and values pandas.DataFrame-s
     #   storing q-values: each column corresponds to a lambda-chunk,
     #   while rows correspond to observed pixels values.
     return pixels_qvalue_df
 
-def clust_2D_pixels(pixels_df,
-                    threshold_cluster=2,
-                    bin1_id_name='bin1_id',
-                    bin2_id_name='bin2_id',
-                    clust_label_name='c_label',
-                    clust_size_name='c_size',
-                    verbose=True):
-    '''
+
+def clust_2D_pixels(
+    pixels_df,
+    threshold_cluster=2,
+    bin1_id_name="bin1_id",
+    bin2_id_name="bin2_id",
+    clust_label_name="c_label",
+    clust_size_name="c_size",
+    verbose=True,
+):
+    """
     Group significant pixels by proximity using Birch clustering. We use
     "n_clusters=None", which implies no AgglomerativeClustering, and thus
     simply reporting "blobs" of pixels of radii <="threshold_cluster" along
@@ -216,10 +236,10 @@ def clust_2D_pixels(pixels_df,
         row/col (bin1/bin2) are coordinates of centroids,
         label and sizes are unique pixel-cluster
         labels and their corresponding sizes.
-    '''
+    """
 
     # col (bin2) must precede row (bin1):
-    pixels     = pixels_df[[bin1_id_name, bin2_id_name]].values.astype(np.float)
+    pixels = pixels_df[[bin1_id_name, bin2_id_name]].values.astype(np.float)
     # added astype(float) to avoid further issues with clustering, as it
     # turned out start1/start2 genome coordinates could be int32 or int64
     # and int32 is not enough for some operations, i.e., integer overflow.
@@ -229,10 +249,12 @@ def clust_2D_pixels(pixels_df,
     # "n_clusters=None" implies using BIRCH without AgglomerativeClustering,
     # thus simply reporting "blobs" of pixels of radius "threshold_cluster"
     # along with blob-centroids as well:
-    brc = Birch(n_clusters=None,
-                threshold=threshold_cluster,
-                # branching_factor=50, (it's default)
-                compute_labels=True)
+    brc = Birch(
+        n_clusters=None,
+        threshold=threshold_cluster,
+        # branching_factor=50, (it's default)
+        compute_labels=True,
+    )
     brc.fit(pixels)
     # # following is redundant,
     # # as it's done here:
@@ -243,45 +265,47 @@ def clust_2D_pixels(pixels_df,
     # BEWARE: labels might not be continuous, i.e.,
     # "np.unique(clustered_labels)" isn't same as "brc.subcluster_labels_", because:
     # https://github.com/scikit-learn/scikit-learn/blob/a24c8b464d094d2c468a16ea9f8bf8d42d949f84/sklearn/cluster/birch.py#L576
-    clustered_labels    = brc.labels_
+    clustered_labels = brc.labels_
     # centroid coordinates ( <= len(clustered_labels)):
     clustered_centroids = brc.subcluster_centers_
     # count unique labels and get their continuous indices
     uniq_labels, inverse_idx, uniq_counts = np.unique(
-                                                clustered_labels,
-                                                return_inverse=True,
-                                                return_counts=True)
+        clustered_labels, return_inverse=True, return_counts=True
+    )
     # cluster sizes taken to match labels:
-    cluster_sizes       = uniq_counts[inverse_idx]
+    cluster_sizes = uniq_counts[inverse_idx]
     # take centroids corresponding to labels (as many as needed):
-    centroids_per_pixel = np.take(clustered_centroids,
-                                  clustered_labels,
-                                  axis=0)
+    centroids_per_pixel = np.take(clustered_centroids, clustered_labels, axis=0)
 
     if verbose:
         # prepare clustering summary report:
-        msg = "Clustering is completed:\n" + \
-              "{} clusters detected\n".format(uniq_counts.size) + \
-              "{:.2f}+/-{:.2f} mean size\n".format(uniq_counts.mean(),
-                                                 uniq_counts.std())
+        msg = (
+            "Clustering is completed:\n"
+            + "{} clusters detected\n".format(uniq_counts.size)
+            + "{:.2f}+/-{:.2f} mean size\n".format(
+                uniq_counts.mean(), uniq_counts.std()
+            )
+        )
         print(msg)
 
     # create output DataFrame
     centroids_n_labels_df = pd.DataFrame(
-                                centroids_per_pixel,
-                                index=pixel_idxs,
-                                columns=['c'+bin1_id_name,'c'+bin2_id_name])
+        centroids_per_pixel,
+        index=pixel_idxs,
+        columns=["c" + bin1_id_name, "c" + bin2_id_name],
+    )
     # add labels per pixel:
     centroids_n_labels_df[clust_label_name] = clustered_labels.astype(np.int)
     # add cluster sizes:
     centroids_n_labels_df[clust_size_name] = cluster_sizes.astype(np.int)
 
-
     return centroids_n_labels_df
+
 
 ##################################
 # matrix tiling and tiles-generator
 ##################################
+
 
 def diagonal_matrix_tiling(start, stop, bandwidth, edge=0, verbose=False):
     """
@@ -335,14 +359,17 @@ def diagonal_matrix_tiling(start, stop, bandwidth, edge=0, verbose=False):
 
     # matrix parameters before chunking:
     if verbose:
-        print("matrix of size {}X{} to be split so that\n".format(size,size)+
-         "  diagonal region of size {} would be completely\n".format(bandwidth)+
-         "  covered by the tiling, additionally keeping\n"+
-         "  a small 'edge' of size w={}, to allow for\n".format(edge)+
-         "  meaningfull convolution around boundaries.\n"+
-         "  Resulting number of tiles is {}".format(tiles-1)+
-         "  Non-edge case size of each tile is {}X{}".format(2*(bandwidth+edge),
-                                                             2*(bandwidth+edge)))
+        print(
+            "matrix of size {}X{} to be split so that\n".format(size, size)
+            + "  diagonal region of size {} would be completely\n".format(bandwidth)
+            + "  covered by the tiling, additionally keeping\n"
+            + "  a small 'edge' of size w={}, to allow for\n".format(edge)
+            + "  meaningfull convolution around boundaries.\n"
+            + "  Resulting number of tiles is {}".format(tiles - 1)
+            + "  Non-edge case size of each tile is {}X{}".format(
+                2 * (bandwidth + edge), 2 * (bandwidth + edge)
+            )
+        )
 
     # actual number of tiles is tiles-1
     # by doing range(1, tiles) we are making sure we are processing the
@@ -350,10 +377,11 @@ def diagonal_matrix_tiling(start, stop, bandwidth, edge=0, verbose=False):
     for t in range(1, tiles):
         # l = max(0,M*t-M)
         # r = min(L,M*t+M)
-        lw = max(0    , bandwidth*(t-1) - edge)
-        rw = min(size , bandwidth*(t+1) + edge)
+        lw = max(0, bandwidth * (t - 1) - edge)
+        rw = min(size, bandwidth * (t + 1) + edge)
         # don't forget about the 'start' origin:
-        yield lw+start, rw+start
+        yield lw + start, rw + start
+
 
 def square_matrix_tiling(start, stop, step, edge, square=False, verbose=False):
     """
@@ -440,26 +468,29 @@ def square_matrix_tiling(start, stop, step, edge, square=False, verbose=False):
     tiles = size // step + bool(size % step)
 
     if verbose:
-        print("matrix of size {}X{} to be splitted\n".format(size,size)+
-         "  into square tiles of size {}.\n".format(step)+
-         "  A small 'edge' of size w={} is added, to allow for\n".format(edge)+
-         "  meaningfull convolution around boundaries.\n"+
-         "  Resulting number of tiles is {}".format(tiles*tiles))
+        print(
+            "matrix of size {}X{} to be splitted\n".format(size, size)
+            + "  into square tiles of size {}.\n".format(step)
+            + "  A small 'edge' of size w={} is added, to allow for\n".format(edge)
+            + "  meaningfull convolution around boundaries.\n"
+            + "  Resulting number of tiles is {}".format(tiles * tiles)
+        )
 
     for tx in range(tiles):
         for ty in range(tiles):
 
-            lwx = max(0,    step*tx - edge)
-            rwx = min(size, step*(tx+1) + edge)
+            lwx = max(0, step * tx - edge)
+            rwx = min(size, step * (tx + 1) + edge)
             if square and (rwx >= size):
                 lwx = size - step - edge
 
-            lwy = max(0,    step*ty - edge)
-            rwy = min(size, step*(ty+1) + edge)
+            lwy = max(0, step * ty - edge)
+            rwy = min(size, step * (ty + 1) + edge)
             if square and (rwy >= size):
                 lwy = size - step - edge
 
-            yield (lwx+start,rwx+start), (lwy+start,rwy+start)
+            yield (lwx + start, rwx + start), (lwy + start, rwy + start)
+
 
 def heatmap_tiles_generator_diag(clr, chroms, pad_size, tile_size, band_to_cover):
     """
@@ -493,26 +524,26 @@ def heatmap_tiles_generator_diag(clr, chroms, pad_size, tile_size, band_to_cover
 
     for chrom in chroms:
         chr_start, chr_stop = clr.extent(chrom)
-        for tilei, tilej in square_matrix_tiling(chr_start,
-                                                 chr_stop,
-                                                 tile_size,
-                                                 pad_size):
+        for tilei, tilej in square_matrix_tiling(
+            chr_start, chr_stop, tile_size, pad_size
+        ):
             # check if a given tile intersects with
             # with the diagonal band of interest ...
             diag_from = tilej[0] - tilei[1]
-            diag_to   = tilej[1] - tilei[0]
+            diag_to = tilej[1] - tilei[0]
             #
             band_from = 0
-            band_to   = band_to_cover
+            band_to = band_to_cover
             # we are using this >2*padding trick to exclude
             # tiles from the lower triangle from calculations ...
-            if (min(band_to,diag_to) - max(band_from,diag_from)) > 2*pad_size:
+            if (min(band_to, diag_to) - max(band_from, diag_from)) > 2 * pad_size:
                 yield chrom, tilei, tilej
+
 
 ##################################
 # kernel-convolution related:
 ##################################
-def _convolve_and_count_nans(O_bal,E_bal,E_raw,N_bal,kernel):
+def _convolve_and_count_nans(O_bal, E_bal, E_raw, N_bal, kernel):
     """
     Dense versions of a bunch of matrices needed for convolution and
     calculation of number of NaNs in a vicinity of each pixel. And a kernel to
@@ -521,32 +552,26 @@ def _convolve_and_count_nans(O_bal,E_bal,E_raw,N_bal,kernel):
     """
     # a matrix filled with the kernel-weighted sums
     # based on a balanced observed matrix:
-    KO = convolve(O_bal,
-                  kernel,
-                  mode='constant',
-                  cval=0.0,
-                  origin=0)
+    KO = convolve(O_bal, kernel, mode="constant", cval=0.0, origin=0)
     # a matrix filled with the kernel-weighted sums
     # based on a balanced expected matrix:
-    KE = convolve(E_bal,
-                  kernel,
-                  mode='constant',
-                  cval=0.0,
-                  origin=0)
+    KE = convolve(E_bal, kernel, mode="constant", cval=0.0, origin=0)
     # get number of NaNs in a vicinity of every
     # pixel (kernel's nonzero footprint)
     # based on the NaN-matrix N_bal.
     # N_bal is shared NaNs between O_bal E_bal,
     # is it redundant ?
-    NN = convolve(N_bal.astype(np.int),
-                  # we have to use kernel's
-                  # nonzero footprint:
-                  (kernel != 0).astype(np.int),
-                  mode='constant',
-                  # there are only NaNs
-                  # beyond the boundary:
-                  cval=1,
-                  origin=0)
+    NN = convolve(
+        N_bal.astype(np.int),
+        # we have to use kernel's
+        # nonzero footprint:
+        (kernel != 0).astype(np.int),
+        mode="constant",
+        # there are only NaNs
+        # beyond the boundary:
+        cval=1,
+        origin=0,
+    )
     ######################################
     # using cval=0 for actual data and
     # cval=1 for NaNs matrix reduces
@@ -561,24 +586,21 @@ def _convolve_and_count_nans(O_bal,E_bal,E_raw,N_bal,kernel):
     # in the form of dense matrices:
     return Ek_raw, NN
 
+
 ########################################################################
 # this should be a MAIN function to get locally adjusted expected
 # Die Hauptfunktion
 ########################################################################
-def get_adjusted_expected_tile_some_nans(origin,
-                                         observed,
-                                         expected,
-                                         bal_weights,
-                                         kernels,
-                                         balance_factor=None,
-                                         verbose=False):
-# ! use parameterized column names
-# # observed_count_name = "count"
-# # expected_count_name = "exp.raw"
-# # adjusted_exp_name = lambda kernel_name: "la_exp."+kernel_name+".value"
-# # nans_inkernel_name = lambda kernel_name: "la_exp."+kernel_name+".nnans"
-# # bin1_id_name='bin1_id'
-# # bin2_id_name='bin2_id'
+def get_adjusted_expected_tile_some_nans(
+    origin, observed, expected, bal_weights, kernels, balance_factor=None, verbose=False
+):
+    # ! use parameterized column names
+    # # observed_count_name = "count"
+    # # expected_count_name = "exp.raw"
+    # # adjusted_exp_name = lambda kernel_name: "la_exp."+kernel_name+".value"
+    # # nans_inkernel_name = lambda kernel_name: "la_exp."+kernel_name+".nnans"
+    # # bin1_id_name='bin1_id'
+    # # bin2_id_name='bin2_id'
 
     """
     'get_adjusted_expected_tile_some_nans', get locally adjusted
@@ -696,28 +718,31 @@ def get_adjusted_expected_tile_some_nans(origin,
     # extract origin coordinate of this tile:
     io, jo = origin
     # let's extract full matrices and ice_vector:
-    O_raw = observed # raw observed, no need to copy, no modifications.
+    O_raw = observed  # raw observed, no need to copy, no modifications.
     E_bal = np.copy(expected)
     # 'bal_weights': ndarray or a couple of those ...
     if isinstance(bal_weights, np.ndarray):
         v_bal_i = bal_weights
         v_bal_j = bal_weights
-    elif isinstance(bal_weights, (tuple,list)):
-        v_bal_i,v_bal_j = bal_weights
+    elif isinstance(bal_weights, (tuple, list)):
+        v_bal_i, v_bal_j = bal_weights
     else:
-        raise ValueError("'bal_weights' must be an numpy.ndarray"
-                    "for slices of a matrix with diagonal-origin or"
-                    "a tuple/list of a couple of numpy.ndarray-s"
-                    "for a slice of matrix with an arbitrary origin.")
+        raise ValueError(
+            "'bal_weights' must be an numpy.ndarray"
+            "for slices of a matrix with diagonal-origin or"
+            "a tuple/list of a couple of numpy.ndarray-s"
+            "for a slice of matrix with an arbitrary origin."
+        )
     # kernels must be a dict with kernel-names as keys
     # and kernel ndarrays as values.
     if not isinstance(kernels, dict):
-        raise ValueError("'kernels' must be a dictionary"
-                    "with name-keys and ndarrays-values.")
+        raise ValueError(
+            "'kernels' must be a dictionary" "with name-keys and ndarrays-values."
+        )
 
     # balanced observed, from raw-observed
     # by element-wise multiply:
-    O_bal = np.multiply(O_raw, np.outer(v_bal_i,v_bal_j))
+    O_bal = np.multiply(O_raw, np.outer(v_bal_i, v_bal_j))
     # O_bal is separate from O_raw memory-wise.
 
     # fill lower triangle of O_bal and E_bal with NaNs
@@ -726,18 +751,17 @@ def get_adjusted_expected_tile_some_nans(origin,
     # estimation for pixels very close to diagonal, whose
     # "donuts"(kernels) would be crossing the main diagonal.
     # The trickiest thing here would be dealing with the origin: io,jo.
-    O_bal[np.tril_indices_from(O_bal,k=(io-jo)-1)] = np.nan
-    E_bal[np.tril_indices_from(E_bal,k=(io-jo)-1)] = np.nan
+    O_bal[np.tril_indices_from(O_bal, k=(io - jo) - 1)] = np.nan
+    E_bal[np.tril_indices_from(E_bal, k=(io - jo) - 1)] = np.nan
 
     # raw E_bal: element-wise division of E_bal[i,j] and
     # v_bal[i]*v_bal[j]:
-    E_raw = np.divide(E_bal, np.outer(v_bal_i,v_bal_j))
+    E_raw = np.divide(E_bal, np.outer(v_bal_i, v_bal_j))
 
     # let's calculate a matrix of common NaNs
     # shared between observed and expected:
     # check if it's redundant ? (is NaNs from O_bal sufficient? )
-    N_bal = np.logical_or(np.isnan(O_bal),
-                          np.isnan(E_bal))
+    N_bal = np.logical_or(np.isnan(O_bal), np.isnan(E_bal))
     # fill in common nan-s with zeroes, preventing
     # NaNs during convolution part of '_convolve_and_count_nans':
     O_bal[N_bal] = 0.0
@@ -749,12 +773,11 @@ def get_adjusted_expected_tile_some_nans(origin,
     # we are going to accumulate all the results
     # into a DataFrame, keeping NaNs, and other
     # unfiltered results (even the lower triangle for now):
-    i,j = np.indices(O_raw.shape)
+    i, j = np.indices(O_raw.shape)
     # pack it into DataFrame to accumulate results:
-    peaks_df = pd.DataFrame({"bin1_id": i.flatten()+io,
-                             "bin2_id": j.flatten()+jo})
+    peaks_df = pd.DataFrame({"bin1_id": i.flatten() + io, "bin2_id": j.flatten() + jo})
 
-    with np.errstate(divide='ignore', invalid='ignore'):
+    with np.errstate(divide="ignore", invalid="ignore"):
         for kernel_name, kernel in kernels.items():
             ###############################
             # kernel-specific calculations:
@@ -776,31 +799,25 @@ def get_adjusted_expected_tile_some_nans(origin,
             # be provided of course.
             # a matrix filled with the kernel-weighted sums
             # based on a balanced observed matrix:
-            KO = convolve(O_bal,
-                          kernel,
-                          mode='constant',
-                          cval=0.0,
-                          origin=0)
+            KO = convolve(O_bal, kernel, mode="constant", cval=0.0, origin=0)
             # a matrix filled with the kernel-weighted sums
             # based on a balanced expected matrix:
-            KE = convolve(E_bal,
-                          kernel,
-                          mode='constant',
-                          cval=0.0,
-                          origin=0)
+            KE = convolve(E_bal, kernel, mode="constant", cval=0.0, origin=0)
             # get number of NaNs in a vicinity of every
             # pixel (kernel's nonzero footprint)
             # based on the NaN-matrix N_bal.
             # N_bal is shared NaNs between O_bal E_bal,
-            NN = convolve(N_bal.astype(np.int),
-                          # we have to use kernel's
-                          # nonzero footprint:
-                          (kernel != 0).astype(np.int),
-                          mode='constant',
-                          # there are only NaNs
-                          # beyond the boundary:
-                          cval=1,
-                          origin=0)
+            NN = convolve(
+                N_bal.astype(np.int),
+                # we have to use kernel's
+                # nonzero footprint:
+                (kernel != 0).astype(np.int),
+                mode="constant",
+                # there are only NaNs
+                # beyond the boundary:
+                cval=1,
+                origin=0,
+            )
             ######################################
             # using cval=0 for actual data and
             # cval=1 for NaNs matrix reduces
@@ -815,7 +832,9 @@ def get_adjusted_expected_tile_some_nans(origin,
             # some results of convolution and multuplt it by the
             # appropriate factor "cooler._load_attrs(‘bins/weight’)[‘scale’]" ...
             if balance_factor and (kernel_name == "lowleft"):
-                peaks_df["factor_balance."+kernel_name+".KerObs"] = balance_factor * KO.flatten()
+                peaks_df["factor_balance." + kernel_name + ".KerObs"] = (
+                    balance_factor * KO.flatten()
+                )
                 # KO*balance_factor: to be compared with 16 ...
             if verbose:
                 print("Convolution with kernel {} is complete.".format(kernel_name))
@@ -823,8 +842,8 @@ def get_adjusted_expected_tile_some_nans(origin,
             # accumulation into single DataFrame:
             # store locally adjusted expected for each kernel
             # and number of NaNs in the footprint of each kernel
-            peaks_df["la_exp."+kernel_name+".value"] = Ek_raw.flatten()
-            peaks_df["la_exp."+kernel_name+".nnans"] = NN.flatten()
+            peaks_df["la_exp." + kernel_name + ".value"] = Ek_raw.flatten()
+            peaks_df["la_exp." + kernel_name + ".nnans"] = NN.flatten()
             # do all the filter/logic/masking etc on the complete DataFrame ...
     #####################################
     # downstream stuff is supposed to be
@@ -841,12 +860,12 @@ def get_adjusted_expected_tile_some_nans(origin,
     mask_ndx = pd.Series(0, index=peaks_df.index, dtype=np.bool)
     for kernel_name, kernel in kernels.items():
         # accummulating with a vector full of 'False':
-        mask_ndx_kernel = ~np.isfinite(peaks_df["la_exp."+kernel_name+".value"])
-        mask_ndx = np.logical_or(mask_ndx_kernel,mask_ndx)
+        mask_ndx_kernel = ~np.isfinite(peaks_df["la_exp." + kernel_name + ".value"])
+        mask_ndx = np.logical_or(mask_ndx_kernel, mask_ndx)
 
     # returning only pixels from upper triangle of a matrix
     # is likely here to stay:
-    upper_band = (peaks_df["bin1_id"] < peaks_df["bin2_id"])
+    upper_band = peaks_df["bin1_id"] < peaks_df["bin2_id"]
     # Consider filling lower triangle of the OBSERVED matrix tile
     # with NaNs, instead of this - we'd need this for a fair
     # consideration of the pixels that are super close to the
@@ -856,17 +875,27 @@ def get_adjusted_expected_tile_some_nans(origin,
     # close etc, is now shifted to the outside of this function
     # a way to simplify code.
 
-
     # return good semi-sparsified DF:
     return peaks_df[~mask_ndx & upper_band].reset_index(drop=True)
 
 
 ##################################
-# step-specific dot-calling functions 
+# step-specific dot-calling functions
 ##################################
 
-def score_tile(tile_cij, clr, cis_exp, exp_v_name, bal_v_name, kernels,
-               nans_tolerated, band_to_cover, balance_factor, verbose):
+
+def score_tile(
+    tile_cij,
+    clr,
+    cis_exp,
+    exp_v_name,
+    bal_v_name,
+    kernels,
+    nans_tolerated,
+    band_to_cover,
+    balance_factor,
+    verbose,
+):
     """
     The main working function that given a tile of a heatmap, applies kernels to
     perform convolution to calculate locally-adjusted expected and then
@@ -933,19 +962,20 @@ def score_tile(tile_cij, clr, cis_exp, exp_v_name, bal_v_name, kernels,
         origin=origin,
         observed=observed,
         expected=expected,
-        bal_weights=(bal_weight_i,bal_weight_j),
+        bal_weights=(bal_weight_i, bal_weight_j),
         kernels=kernels,
         balance_factor=balance_factor,
-        verbose=verbose)
+        verbose=verbose,
+    )
 
     # Post-processing filters
     # (1) exclude pixels that connect loci further than 'band_to_cover' apart:
-    is_inside_band = (result["bin1_id"] > (result["bin2_id"]-band_to_cover))
+    is_inside_band = result["bin1_id"] > (result["bin2_id"] - band_to_cover)
 
     # (2) identify pixels that pass number of NaNs compliance test for ALL kernels:
     does_comply_nans = np.all(
-        result[["la_exp."+k+".nnans" for k in kernels]] < nans_tolerated,
-        axis=1)
+        result[["la_exp." + k + ".nnans" for k in kernels]] < nans_tolerated, axis=1
+    )
     # so, selecting inside band and nNaNs compliant results:
     # ( drop dropping index maybe ??? ) ...
     res_df = result[is_inside_band & does_comply_nans].reset_index(drop=True)
@@ -977,15 +1007,14 @@ def score_tile(tile_cij, clr, cis_exp, exp_v_name, bal_v_name, kernels,
     # rename obs.raw -> count
     # this would break A LOT of downstream stuff - but let it be ...
     #
-    return res_df[["bin1_id","bin2_id","count"]+ \
-                 ["la_exp."+k+".value" for k in kernels]] \
-                  .astype(dtype={"la_exp."+k+".value":'float64' for k in kernels})
+    return res_df[
+        ["bin1_id", "bin2_id", "count"] + ["la_exp." + k + ".value" for k in kernels]
+    ].astype(dtype={"la_exp." + k + ".value": "float64" for k in kernels})
 
-def histogram_scored_pixels(scored_df,
-                            kernels,
-                            ledges,
-                            verbose,
-                            obs_raw_name = observed_count_name):
+
+def histogram_scored_pixels(
+    scored_df, kernels, ledges, verbose, obs_raw_name=observed_count_name
+):
     """
     An attempt to implement HiCCUPS-like lambda-chunking
     statistical procedure.
@@ -1038,7 +1067,6 @@ def histogram_scored_pixels(scored_df,
     # hypothesis in a same "class", i.e. with the l.a. expecteds
     # from the same histogram bin.
 
-
     ########################
     # implementation ideas:
     ########################
@@ -1061,7 +1089,7 @@ def histogram_scored_pixels(scored_df,
         # needs to be histogrammed in every bin : scored_df["obs.raw"]
         #
         # lambda-bin index for kernel-type "k":
-        lbins = pd.cut(scored_df["la_exp."+k+".value"],ledges)
+        lbins = pd.cut(scored_df["la_exp." + k + ".value"], ledges)
         # now for each lambda-bin construct a histogramm of "obs.raw":
         obs_hist = {}
         for lbin, grp_df in scored_df.groupby(lbins):
@@ -1085,6 +1113,7 @@ def histogram_scored_pixels(scored_df,
         hists[k] = pd.DataFrame(obs_hist).fillna(0).astype(np.integer)
     # return a dict of DataFrames with a bunch of histograms:
     return hists
+
 
 def determine_thresholds(kernels, ledges, gw_hist, fdr):
     """
@@ -1123,8 +1152,9 @@ def determine_thresholds(kernels, ledges, gw_hist, fdr):
         rcs_Poisson[k] = pd.DataFrame()
         for mu, column in zip(ledges[1:-1], gw_hist[k].columns):
             renorm_factors = rcs_hist[k].loc[0, column]
-            rcs_Poisson[k][column] = (
-                renorm_factors * poisson.sf(gw_hist[k].index - 1, mu))
+            rcs_Poisson[k][column] = renorm_factors * poisson.sf(
+                gw_hist[k].index - 1, mu
+            )
 
         # Determine the threshold by checking the value at which 'fdr_diff'
         # first turns positive. Fill NaNs with an "unreachably" high value.
@@ -1132,9 +1162,9 @@ def determine_thresholds(kernels, ledges, gw_hist, fdr):
         very_high_value = len(rcs_hist[k])
         threshold_df[k] = (
             fdr_diff.where(fdr_diff > 0)
-                    .apply(lambda col: col.first_valid_index())
-                    .fillna(very_high_value)
-                    .astype(np.integer)
+            .apply(lambda col: col.first_valid_index())
+            .fillna(very_high_value)
+            .astype(np.integer)
         )
         # q-values
         # bear in mind some issues with lots of NaNs and Infs after
@@ -1143,12 +1173,10 @@ def determine_thresholds(kernels, ledges, gw_hist, fdr):
 
     return threshold_df, qvalues
 
-def extract_scored_pixels(scored_df,
-                        kernels,
-                        thresholds,
-                        ledges,
-                        verbose,
-                        obs_raw_name=observed_count_name):
+
+def extract_scored_pixels(
+    scored_df, kernels, thresholds, ledges, verbose, obs_raw_name=observed_count_name
+):
     """
     An attempt to implement HiCCUPS-like lambda-chunking
     statistical procedure.
@@ -1195,8 +1223,10 @@ def extract_scored_pixels(scored_df,
         # i.e. IntervalIndex can be .loc-ed with values that would be
         # corresponded with their Intervals (!!!):
         # obs.raw -> count
-        comply_fdr_k = (scored_df[obs_raw_name].values > \
-                        thresholds[k].loc[scored_df["la_exp."+k+".value"]].values)
+        comply_fdr_k = (
+            scored_df[obs_raw_name].values
+            > thresholds[k].loc[scored_df["la_exp." + k + ".value"]].values
+        )
         # extracting q-values for all of the pixels takes a lot of time
         # we'll do it externally for filtered_pixels only, in order to save
         # time
@@ -1213,9 +1243,21 @@ def extract_scored_pixels(scored_df,
 # basically - the dot-calling steps - ONE PASS DOT-CALLING:
 ##################################
 
-def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
-                 max_nans_tolerated, loci_separation_bins, output_path,
-                 nproc, output_mode, verbose):
+
+def scoring_step(
+    clr,
+    expected,
+    expected_name,
+    balance_name,
+    tiles,
+    kernels,
+    max_nans_tolerated,
+    loci_separation_bins,
+    output_path,
+    nproc,
+    output_mode,
+    verbose,
+):
     """
     Calculates locally adjusted expected
     for each pixel in a designated area of
@@ -1239,15 +1281,19 @@ def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
         # do not calculate dynamic-donut criteria
         # for now.
         balance_factor=None,
-        verbose=very_verbose)
+        verbose=very_verbose,
+    )
 
     if nproc > 1:
         pool = mp.Pool(nproc)
         map_ = pool.imap
-        map_kwargs = dict(chunksize=int(np.ceil(len(tiles)/nproc)))
+        map_kwargs = dict(chunksize=int(np.ceil(len(tiles) / nproc)))
         if verbose:
-            print("creating a Pool of {} workers to tackle {} tiles".format(
-                    nproc, len(tiles)))
+            print(
+                "creating a Pool of {} workers to tackle {} tiles".format(
+                    nproc, len(tiles)
+                )
+            )
     else:
         map_ = map
         if verbose:
@@ -1268,12 +1314,14 @@ def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
             print("pandas hdf output ...")
             append = False
             for chunk in chunks:
-                chunk.to_hdf(output_path,
-                             key='results',
-                             format='table',
-                             complevel=9,
-                             complib="blosc:snappy",
-                             append=append)
+                chunk.to_hdf(
+                    output_path,
+                    key="results",
+                    format="table",
+                    complevel=9,
+                    complib="blosc:snappy",
+                    append=append,
+                )
                 append = True
             # success
             return 0
@@ -1287,24 +1335,26 @@ def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
             # "create_cooler" API needs more consistency:
             # https://github.com/mirnylab/cooler/issues/149
             #  manually describing "data"-columns (except for bin_ids).
-            columns = ['count',]+["la_exp."+k+".value" for k in kernels]
+            columns = ["count",] + ["la_exp." + k + ".value" for k in kernels]
             # # dtype them just in case as well:
             # dtypes = {"la_exp."+k+".value":np.float64 for k in kernels}
             # dtypes["count"] = np.int32
             # create_cooler using buffered chunks iterator, to speed up
             # cooler merge, as suggested by @nvictus
-            cooler.create_cooler(output_path,
-                                clr.bins()[:],
-                                # iterator of larger pixel chunks ...
-                                buffer_df_chunks(chunks),
-                                columns=columns,
-                                # dtypes=dtypes,
-                                # # to be included later, copy from original clr?
-                                # metadata : dict, optional
-                                # assembly : str, optional
-                                ordered = False, # not ordered for sure
-                                symmetric_upper = True, # is it really ? should be
-                                mode = 'w')
+            cooler.create_cooler(
+                output_path,
+                clr.bins()[:],
+                # iterator of larger pixel chunks ...
+                buffer_df_chunks(chunks),
+                columns=columns,
+                # dtypes=dtypes,
+                # # to be included later, copy from original clr?
+                # metadata : dict, optional
+                # assembly : str, optional
+                ordered=False,  # not ordered for sure
+                symmetric_upper=True,  # is it really ? should be
+                mode="w",
+            )
             # success
             return 0
         # ###########################################
@@ -1322,7 +1372,7 @@ def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
                 # compression='snappy',
                 # use_dictionary=True,
                 # version=2.0
-                )
+            )
             # success
             return 0
         # ###########################################
@@ -1339,7 +1389,10 @@ def scoring_step(clr, expected, expected_name, balance_name, tiles, kernels,
         if nproc > 1:
             pool.close()
 
-def histogramming_step(scores_input, input_mode, kernels, ledges, output_path=None, nproc=1, verbose=False):
+
+def histogramming_step(
+    scores_input, input_mode, kernels, ledges, output_path=None, nproc=1, verbose=False
+):
     """
     This is an implementation of the 1st step of lambda-chunking - histogramming.
     This function expects a BEDPE-style dataframe with the scores to be
@@ -1388,13 +1441,14 @@ def histogramming_step(scores_input, input_mode, kernels, ledges, output_path=No
 
     # add very_verbose to supress output from convolution of every tile
     very_verbose = False
-        
+
     if input_mode == "parquet":
         print("parquet input ...")
         # quick attempt - to be updated later
         # ask @nvictus for best practises
         #  wrap it in try statement at least ...
         from pyarrow.parquet import ParquetFile
+
         # check if scored_input is of str instance
         # or a file handle or whatever ...
         pf = ParquetFile(scores_input)
@@ -1410,21 +1464,20 @@ def histogramming_step(scores_input, input_mode, kernels, ledges, output_path=No
     else:
         raise ValueError("{} mode is not supported".format(input_mode))
 
-
     # to hist per scored chunk:
     to_hist = partial(
-        histogram_scored_pixels,
-        kernels=kernels,
-        ledges=ledges,
-        verbose=very_verbose)
+        histogram_scored_pixels, kernels=kernels, ledges=ledges, verbose=very_verbose
+    )
 
     # composing/piping scoring and histogramming
     # together :
-    job = lambda tile : to_hist(extract_df(tile))
+    job = lambda tile: to_hist(extract_df(tile))
 
     # copy paste from @nvictus modified 'scoring_step':
     if nproc > 1:
-        raise  NotImplementedError("reading parquet in chunks using multiprocess breaks!")
+        raise NotImplementedError(
+            "reading parquet in chunks using multiprocess breaks!"
+        )
         # pool = mp.Pool(nproc)
         # map_ = pool.imap
         # map_kwargs = dict(chunksize=int(np.ceil(len(tiles)/nproc)))
@@ -1455,12 +1508,12 @@ def histogramming_step(scores_input, input_mode, kernels, ledges, output_path=No
     # this is very ugly, but ok
     # for the draft lambda-chunking
     # lambda version of lambda-chunking:
-    def _sum_hists(hx,hy):
+    def _sum_hists(hx, hy):
         # perform a DataFrame summation
         # for every value of the dictionary:
         hxy = {}
         for k in kernels:
-            hxy[k] = hx[k].add(hy[k],fill_value=0).astype(np.integer)
+            hxy[k] = hx[k].add(hy[k], fill_value=0).astype(np.integer)
         # returning the sum:
         return hxy
 
@@ -1477,27 +1530,32 @@ def histogramming_step(scores_input, input_mode, kernels, ledges, output_path=No
     # top bin, i.e., there are no l.a. expecteds > base^(len(ledges)-1)
     for k in kernels:
         last_la_exp_bin = final_hist[k].columns[-1]
-        last_la_exp_vals = final_hist[k].iloc[:,-1]
+        last_la_exp_vals = final_hist[k].iloc[:, -1]
         # checking the top bin:
-        assert (last_la_exp_vals.sum()==0), \
-                "There are la_exp.{}.value in {}, please check the histogram" \
-                                                    .format(k,last_la_exp_bin)
+        assert (
+            last_la_exp_vals.sum() == 0
+        ), "There are la_exp.{}.value in {}, please check the histogram".format(
+            k, last_la_exp_bin
+        )
         # drop that last column/bin (last_edge, +inf]:
         final_hist[k] = final_hist[k].drop(columns=last_la_exp_bin)
         # consider dropping all of the columns that have zero .sum()
     # returning filtered histogram
     return final_hist
 
-def extraction_step(scores_input,
-                    input_mode,
-                    kernels,
-                    ledges,
-                    thresholds,
-                    nproc=1,
-                    output_path=None,
-                    verbose=False,
-                    bin1_id_name='bin1_id',
-                    bin2_id_name='bin2_id'):
+
+def extraction_step(
+    scores_input,
+    input_mode,
+    kernels,
+    ledges,
+    thresholds,
+    nproc=1,
+    output_path=None,
+    verbose=False,
+    bin1_id_name="bin1_id",
+    bin2_id_name="bin2_id",
+):
     """
 
     This would be an implementation of the second step of lambda-chunking, i.e.
@@ -1567,6 +1625,7 @@ def extraction_step(scores_input,
         # ask @nvictus for best practises
         #  wrap it in try statement at least ...
         from pyarrow.parquet import ParquetFile
+
         # check if scored_input is of str instance
         # or a file handle or whatever ...
         pf = ParquetFile(scores_input)
@@ -1582,22 +1641,24 @@ def extraction_step(scores_input,
     else:
         raise ValueError("{} mode is not supported".format(input_mode))
 
-
     # to hist per scored chunk:
     extract_significant = partial(
         extract_scored_pixels,
         kernels=kernels,
         thresholds=thresholds,
         ledges=ledges,
-        verbose=very_verbose)
+        verbose=very_verbose,
+    )
 
     # composing/piping scoring and histogramming
     # together :
-    job = lambda tile : extract_significant(extract_df(tile))
+    job = lambda tile: extract_significant(extract_df(tile))
 
     # copy paste from @nvictus modified 'scoring_step':
     if nproc > 1:
-        raise  NotImplementedError("reading parquet in chunks using multiprocess breaks!")
+        raise NotImplementedError(
+            "reading parquet in chunks using multiprocess breaks!"
+        )
     else:
         map_ = map
         if verbose:
@@ -1608,28 +1669,34 @@ def extraction_step(scores_input,
         # https://github.com/mirnylab/cooler/blob/9e72ee202b0ac6f9d93fd2444d6f94c524962769/cooler/tools.py#L59
         # here:
         filtered_pix_chunks = map_(job, tiles, **map_kwargs)
-        significant_pixels = pd.concat(filtered_pix_chunks,ignore_index=True)
+        significant_pixels = pd.concat(filtered_pix_chunks, ignore_index=True)
         if output_path is not None:
-            significant_pixels.to_csv(output_path,
-                                      sep='\t',
-                                      header=True,
-                                      index=False,
-                                      compression=None)
+            significant_pixels.to_csv(
+                output_path, sep="\t", header=True, index=False, compression=None
+            )
     finally:
         if nproc > 1:
             pool.close()
     # there should be no duplicates in the "significant_pixels" DataFrame of pixels:
     significant_pixels_dups = significant_pixels.duplicated()
-    assert not significant_pixels_dups.any(), \
-         "Duplicated pixels detected during exctraction {}". \
-            format(significant_pixels[significant_pixels_dups])
+    assert (
+        not significant_pixels_dups.any()
+    ), "Duplicated pixels detected during exctraction {}".format(
+        significant_pixels[significant_pixels_dups]
+    )
     # sort the result just in case and drop its index:
-    return significant_pixels \
-                .sort_values(by=[bin1_id_name,bin2_id_name]) \
-                .reset_index(drop=True)
+    return significant_pixels.sort_values(by=[bin1_id_name, bin2_id_name]).reset_index(
+        drop=True
+    )
 
-def clustering_step(scores_df, expected_chroms,
-                          dots_clustering_radius, verbose, obs_raw_name = observed_count_name):
+
+def clustering_step(
+    scores_df,
+    expected_chroms,
+    dots_clustering_radius,
+    verbose,
+    obs_raw_name=observed_count_name,
+):
     """
 
     This is a new "clustering" step updated for the pixels processed by lambda-
@@ -1668,23 +1735,28 @@ def clustering_step(scores_df, expected_chroms,
     # using different bin12_id_names since all
     # pixels are annotated at this point.
     pixel_clust_list = []
-    for chrom  in expected_chroms:
+    for chrom in expected_chroms:
         # probably generate one big DataFrame with clustering
         # information only and then just merge it with the
         # existing 'scores_df'-DataFrame.
         # should we use groupby instead of 'scores_df['chrom12']==chrom' ?!
         # to be tested ...
-        df = scores_df[((scores_df['chrom1'].astype(str)==str(chrom)) &
-                        (scores_df['chrom2'].astype(str)==str(chrom)))]
+        df = scores_df[
+            (
+                (scores_df["chrom1"].astype(str) == str(chrom))
+                & (scores_df["chrom2"].astype(str) == str(chrom))
+            )
+        ]
         if not len(df):
             continue
 
         pixel_clust = clust_2D_pixels(
             df,
             threshold_cluster=dots_clustering_radius,
-            bin1_id_name='start1',
-            bin2_id_name='start2',
-            verbose=verbose)
+            bin1_id_name="start1",
+            bin2_id_name="start2",
+            verbose=verbose,
+        )
         pixel_clust_list.append(pixel_clust)
     if verbose:
         print("Clustering is over!")
@@ -1695,20 +1767,18 @@ def clustering_step(scores_df, expected_chroms,
     # now merge pixel_clust_df and scores_df DataFrame ...
     # # and merge (index-wise) with the main DataFrame:
     df = pd.merge(
-        scores_df,
-        pixel_clust_df,
-        how='left',
-        left_index=True,
-        right_index=True)
+        scores_df, pixel_clust_df, how="left", left_index=True, right_index=True
+    )
 
     # report only centroids with highest Observed:
     chrom_clust_group = df.groupby(["chrom1", "chrom2", "c_label"])
     centroids = df.loc[chrom_clust_group[obs_raw_name].idxmax()]
     return centroids
 
+
 # consider switching step names - "extraction" to "FDR-thresholding"
 # and "thresholding" to "enrichment" - for final enrichment selection:
-def thresholding_step(centroids, obs_raw_name = observed_count_name):
+def thresholding_step(centroids, obs_raw_name=observed_count_name):
     # (2)
     # filter by FDR, enrichment etc:
     enrichment_factor_1 = 1.5
@@ -1719,17 +1789,43 @@ def thresholding_step(centroids, obs_raw_name = observed_count_name):
     # # Temporarily remove orphans filtering, until q-vals are calculated:
     ######################################################################
     enrichment_fdr_comply = (
-        (centroids[obs_raw_name] > enrichment_factor_2 * centroids["la_exp.lowleft.value"]) &
-        (centroids[obs_raw_name] > enrichment_factor_2 * centroids["la_exp.donut.value"]) &
-        (centroids[obs_raw_name] > enrichment_factor_1 * centroids["la_exp.vertical.value"]) &
-        (centroids[obs_raw_name] > enrichment_factor_1 * centroids["la_exp.horizontal.value"]) &
-        ( (centroids[obs_raw_name] > enrichment_factor_3 * centroids["la_exp.lowleft.value"])
-            | (centroids[obs_raw_name] > enrichment_factor_3 * centroids["la_exp.donut.value"]) ) &
-        ( (centroids["c_size"] > 1)
-           | ((centroids["la_exp.lowleft.qval"]
-               + centroids["la_exp.donut.qval"]
-               + centroids["la_exp.vertical.qval"]
-               + centroids["la_exp.horizontal.qval"]) <= FDR_orphan_threshold)
+        (
+            centroids[obs_raw_name]
+            > enrichment_factor_2 * centroids["la_exp.lowleft.value"]
+        )
+        & (
+            centroids[obs_raw_name]
+            > enrichment_factor_2 * centroids["la_exp.donut.value"]
+        )
+        & (
+            centroids[obs_raw_name]
+            > enrichment_factor_1 * centroids["la_exp.vertical.value"]
+        )
+        & (
+            centroids[obs_raw_name]
+            > enrichment_factor_1 * centroids["la_exp.horizontal.value"]
+        )
+        & (
+            (
+                centroids[obs_raw_name]
+                > enrichment_factor_3 * centroids["la_exp.lowleft.value"]
+            )
+            | (
+                centroids[obs_raw_name]
+                > enrichment_factor_3 * centroids["la_exp.donut.value"]
+            )
+        )
+        & (
+            (centroids["c_size"] > 1)
+            | (
+                (
+                    centroids["la_exp.lowleft.qval"]
+                    + centroids["la_exp.donut.qval"]
+                    + centroids["la_exp.vertical.qval"]
+                    + centroids["la_exp.horizontal.qval"]
+                )
+                <= FDR_orphan_threshold
+            )
         )
     )
     # #
@@ -1789,29 +1885,29 @@ def thresholding_step(centroids, obs_raw_name = observed_count_name):
 
     # tentaive output columns list:
     columns_for_output = [
-        'chrom1',
-        'start1',
-        'end1',
-        'chrom2',
-        'start2',
-        'end2',
-        'cstart1',
-        'cstart2',
-        'c_label',
-        'c_size',
+        "chrom1",
+        "start1",
+        "end1",
+        "chrom2",
+        "start2",
+        "end2",
+        "cstart1",
+        "cstart2",
+        "c_label",
+        "c_size",
         obs_raw_name,
         # 'exp.raw',
-        'la_exp.donut.value',
-        'la_exp.vertical.value',
-        'la_exp.horizontal.value',
-        'la_exp.lowleft.value',
+        "la_exp.donut.value",
+        "la_exp.vertical.value",
+        "la_exp.horizontal.value",
+        "la_exp.lowleft.value",
         # "factor_balance.lowleft.KerObs",
         # 'la_exp.upright.value',
         # 'la_exp.upright.qval',
-        'la_exp.donut.qval',
-        'la_exp.vertical.qval',
-        'la_exp.horizontal.qval',
-        'la_exp.lowleft.qval'
+        "la_exp.donut.qval",
+        "la_exp.vertical.qval",
+        "la_exp.horizontal.qval",
+        "la_exp.lowleft.qval",
     ]
     return out[columns_for_output]
 
@@ -1821,8 +1917,20 @@ def thresholding_step(centroids, obs_raw_name = observed_count_name):
 # basically - the dot-calling steps - ON THE FLY - 2 PASS DOT-CALLING (HiCCUPS-style):
 ##################################
 
-def scoring_and_histogramming_step(clr, expected, expected_name, balance_name, tiles, kernels,
-                                   ledges, max_nans_tolerated, loci_separation_bins, nproc, verbose):
+
+def scoring_and_histogramming_step(
+    clr,
+    expected,
+    expected_name,
+    balance_name,
+    tiles,
+    kernels,
+    ledges,
+    max_nans_tolerated,
+    loci_separation_bins,
+    nproc,
+    verbose,
+):
     """
     This is a derivative of the 'scoring_step' which is supposed to implement
     the 1st of the lambda-chunking procedure - histogramming.
@@ -1849,27 +1957,29 @@ def scoring_and_histogramming_step(clr, expected, expected_name, balance_name, t
         # do not calculate dynamic-donut criteria
         # for now.
         balance_factor=None,
-        verbose=very_verbose)
+        verbose=very_verbose,
+    )
 
     # to hist per scored chunk:
     to_hist = partial(
-        histogram_scored_pixels,
-        kernels=kernels,
-        ledges=ledges,
-        verbose=very_verbose)
+        histogram_scored_pixels, kernels=kernels, ledges=ledges, verbose=very_verbose
+    )
 
     # composing/piping scoring and histogramming
     # together :
-    job = lambda tile : to_hist(to_score(tile))
+    job = lambda tile: to_hist(to_score(tile))
 
     # copy paste from @nvictus modified 'scoring_step':
     if nproc > 1:
         pool = mp.Pool(nproc)
         map_ = pool.imap
-        map_kwargs = dict(chunksize=int(np.ceil(len(tiles)/nproc)))
+        map_kwargs = dict(chunksize=int(np.ceil(len(tiles) / nproc)))
         if verbose:
-            print("creating a Pool of {} workers to tackle {} tiles".format(
-                    nproc, len(tiles)))
+            print(
+                "creating a Pool of {} workers to tackle {} tiles".format(
+                    nproc, len(tiles)
+                )
+            )
     else:
         map_ = map
         if verbose:
@@ -1894,12 +2004,12 @@ def scoring_and_histogramming_step(clr, expected, expected_name, balance_name, t
     # this is very ugly, but ok
     # for the draft lambda-chunking
     # lambda version of lambda-chunking:
-    def _sum_hists(hx,hy):
+    def _sum_hists(hx, hy):
         # perform a DataFrame summation
         # for every value of the dictionary:
         hxy = {}
         for k in kernels:
-            hxy[k] = hx[k].add(hy[k],fill_value=0).astype(np.integer)
+            hxy[k] = hx[k].add(hy[k], fill_value=0).astype(np.integer)
         # returning the sum:
         return hxy
 
@@ -1916,21 +2026,38 @@ def scoring_and_histogramming_step(clr, expected, expected_name, balance_name, t
     # top bin, i.e., there are no l.a. expecteds > base^(len(ledges)-1)
     for k in kernels:
         last_la_exp_bin = final_hist[k].columns[-1]
-        last_la_exp_vals = final_hist[k].iloc[:,-1]
+        last_la_exp_vals = final_hist[k].iloc[:, -1]
         # checking the top bin:
-        assert (last_la_exp_vals.sum()==0), \
-                "There are la_exp.{}.value in {}, please check the histogram" \
-                                                    .format(k,last_la_exp_bin)
+        assert (
+            last_la_exp_vals.sum() == 0
+        ), "There are la_exp.{}.value in {}, please check the histogram".format(
+            k, last_la_exp_bin
+        )
         # drop that last column/bin (last_edge, +inf]:
         final_hist[k] = final_hist[k].drop(columns=last_la_exp_bin)
         # consider dropping all of the columns that have zero .sum()
     # returning filtered histogram
     return final_hist
 
-def scoring_and_extraction_step(clr, expected, expected_name, balance_name, tiles, kernels,
-                               ledges, thresholds, max_nans_tolerated,
-                               balance_factor, loci_separation_bins, output_path,
-                               nproc, verbose, bin1_id_name='bin1_id', bin2_id_name='bin2_id'):
+
+def scoring_and_extraction_step(
+    clr,
+    expected,
+    expected_name,
+    balance_name,
+    tiles,
+    kernels,
+    ledges,
+    thresholds,
+    max_nans_tolerated,
+    balance_factor,
+    loci_separation_bins,
+    output_path,
+    nproc,
+    verbose,
+    bin1_id_name="bin1_id",
+    bin2_id_name="bin2_id",
+):
     """
     This is a derivative of the 'scoring_step' which is supposed to implement
     the 2nd of the lambda-chunking procedure - extracting pixels that are FDR
@@ -1957,7 +2084,8 @@ def scoring_and_extraction_step(clr, expected, expected_name, balance_name, tile
         nans_tolerated=max_nans_tolerated,
         band_to_cover=loci_separation_bins,
         balance_factor=balance_factor,
-        verbose=very_verbose)
+        verbose=very_verbose,
+    )
 
     # to hist per scored chunk:
     to_extract = partial(
@@ -1965,20 +2093,24 @@ def scoring_and_extraction_step(clr, expected, expected_name, balance_name, tile
         kernels=kernels,
         thresholds=thresholds,
         ledges=ledges,
-        verbose=very_verbose)
+        verbose=very_verbose,
+    )
 
     # composing/piping scoring and histogramming
     # together :
-    job = lambda tile : to_extract(to_score(tile))
+    job = lambda tile: to_extract(to_score(tile))
 
     # copy paste from @nvictus modified 'scoring_step':
     if nproc > 1:
         pool = mp.Pool(nproc)
         map_ = pool.imap
-        map_kwargs = dict(chunksize=int(np.ceil(len(tiles)/nproc)))
+        map_kwargs = dict(chunksize=int(np.ceil(len(tiles) / nproc)))
         if verbose:
-            print("creating a Pool of {} workers to tackle {} tiles".format(
-                    nproc, len(tiles)))
+            print(
+                "creating a Pool of {} workers to tackle {} tiles".format(
+                    nproc, len(tiles)
+                )
+            )
     else:
         map_ = map
         if verbose:
@@ -1989,31 +2121,32 @@ def scoring_and_extraction_step(clr, expected, expected_name, balance_name, tile
         # https://github.com/mirnylab/cooler/blob/9e72ee202b0ac6f9d93fd2444d6f94c524962769/cooler/tools.py#L59
         # here:
         filtered_pix_chunks = map_(job, tiles, **map_kwargs)
-        significant_pixels = pd.concat(filtered_pix_chunks,ignore_index=True)
+        significant_pixels = pd.concat(filtered_pix_chunks, ignore_index=True)
         if output_path is not None:
-            significant_pixels.to_csv(output_path,
-                                      sep='\t',
-                                      header=True,
-                                      index=False,
-                                      compression=None)
+            significant_pixels.to_csv(
+                output_path, sep="\t", header=True, index=False, compression=None
+            )
     finally:
         if nproc > 1:
             pool.close()
     # there should be no duplicates in the "significant_pixels" DataFrame of pixels:
     significant_pixels_dups = significant_pixels.duplicated()
-    assert not significant_pixels_dups.any(), \
-         "Duplicated pixels detected during exctraction {}". \
-            format(significant_pixels[significant_pixels_dups])
+    assert (
+        not significant_pixels_dups.any()
+    ), "Duplicated pixels detected during exctraction {}".format(
+        significant_pixels[significant_pixels_dups]
+    )
     # sort the result just in case and drop its index:
-    return significant_pixels \
-                .sort_values(by=[bin1_id_name,bin2_id_name]) \
-                .reset_index(drop=True)
+    return significant_pixels.sort_values(by=[bin1_id_name, bin2_id_name]).reset_index(
+        drop=True
+    )
+
 
 ##################################
 # OLD functions - to be retired :
 ##################################
 def get_qvals(pvals):
-    '''
+    """
     B&H FDR control procedure: sort a given array of N p-values, determine their
     rank i and then for each p-value compute a corres- ponding q-value, which is
     a minimum FDR at which that given p-value would pass a BH-FDR test.
@@ -2041,22 +2174,30 @@ def get_qvals(pvals):
     - Using alpha=0.02 it is possible to achieve called dots similar to
     pre-update status alpha is meant to be a q-value threshold: "qvals <= alpha"
 
-    '''
+    """
     # NOTE: This is tested and is capable of reproducing
     # `multiple_test_BH` results
     pvals = np.asarray(pvals)
     n_obs = pvals.size
     # determine rank of p-values (1-indexed):
     porder = np.argsort(pvals)
-    prank  = np.empty_like(porder)
-    prank[porder] = np.arange(1, n_obs+1)
+    prank = np.empty_like(porder)
+    prank[porder] = np.arange(1, n_obs + 1)
     # q-value = p-value*N_obs/i(rank of a p-value) ...
-    qvals = np.true_divide(n_obs*pvals, prank)
+    qvals = np.true_divide(n_obs * pvals, prank)
     # return the qvals sorted as the initial pvals:
     return qvals
 
-def clustering_step_old(scores_file, expected_chroms, ktypes, fdr,
-                    dots_clustering_radius, verbose, obs_raw_name = observed_count_name):
+
+def clustering_step_old(
+    scores_file,
+    expected_chroms,
+    ktypes,
+    fdr,
+    dots_clustering_radius,
+    verbose,
+    obs_raw_name=observed_count_name,
+):
     """
     This is an old "clustering" step, before lambda-chunking
     was implemented.
@@ -2067,17 +2208,17 @@ def clustering_step_old(scores_file, expected_chroms, ktypes, fdr,
     hdf file, and it would try to read the entire file in
     memory.
     """
-    res_df = pd.read_hdf(scores_file, 'results')
+    res_df = pd.read_hdf(scores_file, "results")
 
     # do Benjamin-Hochberg FDR multiple hypothesis tests
     # genome-wide:
     for k in ktypes:
-        res_df["la_exp."+k+".qval"] = get_qvals( res_df["la_exp."+k+".pval"] )
+        res_df["la_exp." + k + ".qval"] = get_qvals(res_df["la_exp." + k + ".pval"])
 
     # combine results of all tests:
-    res_df['comply_fdr'] = np.all(
-        res_df[["la_exp."+k+".qval" for k in ktypes]] <= fdr,
-        axis=1)
+    res_df["comply_fdr"] = np.all(
+        res_df[["la_exp." + k + ".qval" for k in ktypes]] <= fdr, axis=1
+    )
 
     # print a message for timing:
     if verbose:
@@ -2086,22 +2227,27 @@ def clustering_step_old(scores_file, expected_chroms, ktypes, fdr,
     # using different bin12_id_names since all
     # pixels are annotated at this point.
     pixel_clust_list = []
-    for chrom  in expected_chroms:
+    for chrom in expected_chroms:
         # probably generate one big DataFrame with clustering
         # information only and then just merge it with the
         # existing 'res_df'-DataFrame.
         # should we use groupby instead of 'res_df['chrom12']==chrom' ?!
         # to be tested ...
-        df = res_df[(res_df['comply_fdr'] &
-                    (res_df['chrom1']==chrom) &
-                    (res_df['chrom2']==chrom))]
+        df = res_df[
+            (
+                res_df["comply_fdr"]
+                & (res_df["chrom1"] == chrom)
+                & (res_df["chrom2"] == chrom)
+            )
+        ]
 
         pixel_clust = clust_2D_pixels(
             df,
             threshold_cluster=dots_clustering_radius,
-            bin1_id_name='start1',
-            bin2_id_name='start2',
-            verbose=verbose)
+            bin1_id_name="start1",
+            bin2_id_name="start2",
+            verbose=verbose,
+        )
         pixel_clust_list.append(pixel_clust)
     if verbose:
         print("Clustering is over!")
@@ -2112,11 +2258,12 @@ def clustering_step_old(scores_file, expected_chroms, ktypes, fdr,
     # now merge pixel_clust_df and res_df DataFrame ...
     # # and merge (index-wise) with the main DataFrame:
     df = pd.merge(
-        res_df[res_df['comply_fdr']],
+        res_df[res_df["comply_fdr"]],
         pixel_clust_df,
-        how='left',
+        how="left",
         left_index=True,
-        right_index=True)
+        right_index=True,
+    )
 
     # report only centroids with highest Observed:
     chrom_clust_group = df.groupby(["chrom1", "chrom2", "c_label"])

--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -30,20 +30,20 @@ def _phase_eigs(eigvals, eigvecs, phasing_track, sort_metric=None):
     corrs = []
     for eigvec in eigvecs:
         mask = np.isfinite(eigvec) & np.isfinite(phasing_track)
-        if sort_metric is None or sort_metric == 'spearmanr':
+        if sort_metric is None or sort_metric == "spearmanr":
             corr = scipy.stats.spearmanr(phasing_track[mask], eigvec[mask])[0]
-        elif sort_metric == 'pearsonr':
+        elif sort_metric == "pearsonr":
             corr = scipy.stats.pearsonr(phasing_track[mask], eigvec[mask])[0]
-        elif sort_metric == 'var_explained':
+        elif sort_metric == "var_explained":
             corr = scipy.stats.pearsonr(phasing_track[mask], eigvec[mask])[0]
             # multiply by the sign to keep the phasing information
             corr = np.sign(corr) * corr * corr * np.var(eigvec[mask])
-        elif sort_metric == 'MAD_explained':
-            corr = (
-                numutils.COMED(phasing_track[mask], eigvec[mask])
-                * numutils.MAD(eigvec[mask]))
+        elif sort_metric == "MAD_explained":
+            corr = numutils.COMED(phasing_track[mask], eigvec[mask]) * numutils.MAD(
+                eigvec[mask]
+            )
         else:
-            raise ValueError('Unknown sorting metric: {}'.format(sort_by))
+            raise ValueError("Unknown sorting metric: {}".format(sort_by))
 
         corrs.append(corr)
 
@@ -59,8 +59,9 @@ def _phase_eigs(eigvals, eigvecs, phasing_track, sort_metric=None):
     return eigvals, eigvecs
 
 
-def cis_eig(A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0,
-            sort_metric=None):
+def cis_eig(
+    A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0, sort_metric=None
+):
     """
     Compute compartment eigenvector on a dense cis matrix
     Note that the amplitude of compartment eigenvectors is weighted by their corresponding eigenvalue
@@ -111,7 +112,7 @@ def cis_eig(A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0,
 
     mask = A.sum(axis=0) > 0
 
-    if A.shape[0] <= ignore_diags + 3 or mask.sum() <= ignore_diags+3:
+    if A.shape[0] <= ignore_diags + 3 or mask.sum() <= ignore_diags + 3:
         return (
             np.array([np.nan for i in range(n_eigs)]),
             np.array([np.ones(A.shape[0]) * np.nan for i in range(n_eigs)]),
@@ -124,8 +125,7 @@ def cis_eig(A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0,
     OE, _, _, _ = numutils.observed_over_expected(A, mask)
 
     if clip_percentile and clip_percentile < 100:
-        OE = np.clip(OE, 0, np.percentile(
-            OE[mask, :][:, mask], clip_percentile))
+        OE = np.clip(OE, 0, np.percentile(OE[mask, :][:, mask], clip_percentile))
 
     # subtract 1.0
     OE -= 1.0
@@ -135,13 +135,12 @@ def cis_eig(A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0,
     OE[:, ~mask] = 0
 
     eigvecs, eigvals = numutils.get_eig(OE, n_eigs, mask_zero_rows=True)
-    eigvecs /= np.sqrt(np.nansum(eigvecs**2, axis=1))[:, None]
+    eigvecs /= np.sqrt(np.nansum(eigvecs ** 2, axis=1))[:, None]
     eigvecs *= np.sqrt(np.abs(eigvals))[:, None]
 
     # Orient and reorder
     if phasing_track is not None:
-        eigvals, eigvecs = _phase_eigs(
-            eigvals, eigvecs, phasing_track, sort_metric)
+        eigvals, eigvecs = _phase_eigs(eigvals, eigvecs, phasing_track, sort_metric)
 
     return eigvals, eigvecs
 
@@ -172,8 +171,15 @@ def _fake_cis(A, cismask):
     return A
 
 
-def trans_eig(A, partition, n_eigs=3, perc_top=99.95, perc_bottom=1,
-              phasing_track=None, sort_metric=False):
+def trans_eig(
+    A,
+    partition,
+    n_eigs=3,
+    perc_top=99.95,
+    perc_bottom=1,
+    phasing_track=None,
+    sort_metric=False,
+):
     """
     Compute compartmentalization eigenvectors on trans contact data
 
@@ -226,11 +232,13 @@ def trans_eig(A, partition, n_eigs=3, perc_top=99.95, perc_bottom=1,
         raise ValueError("A is not symmetric")
 
     n_bins = A.shape[0]
-    if not (partition[0] == 0 and
-            partition[-1] == n_bins and
-            np.all(np.diff(partition) > 0)):
-        raise ValueError("Not a valid partition. Must be a monotonic sequence "
-                         "from 0 to {}.".format(n_bins))
+    if not (
+        partition[0] == 0 and partition[-1] == n_bins and np.all(np.diff(partition) > 0)
+    ):
+        raise ValueError(
+            "Not a valid partition. Must be a monotonic sequence "
+            "from 0 to {}.".format(n_bins)
+        )
 
     # Delete cis data and create trans mask
     extents = zip(partition[:-1], partition[1:])
@@ -239,7 +247,7 @@ def trans_eig(A, partition, n_eigs=3, perc_top=99.95, perc_bottom=1,
         A[i0:i1, i0:i1] = 0
         part_ids.extend([n] * (i1 - i0))
     part_ids = np.array(part_ids)
-    is_trans = (part_ids[:, None] != part_ids[None, :])
+    is_trans = part_ids[:, None] != part_ids[None, :]
 
     # Filter heatmap
     is_bad_bin = np.nansum(A, axis=0) == 0
@@ -269,63 +277,66 @@ def trans_eig(A, partition, n_eigs=3, perc_top=99.95, perc_bottom=1,
     O[:, is_bad_bin] = 0
     eigvecs, eigvals = numutils.get_eig(O, n_eigs, mask_zero_rows=True)
 
-    eigvecs /= np.sqrt(np.nansum(eigvecs**2, axis=1))[:, None]
+    eigvecs /= np.sqrt(np.nansum(eigvecs ** 2, axis=1))[:, None]
     eigvecs *= np.sqrt(np.abs(eigvals))[:, None]
     if phasing_track is not None:
-        eigvals, eigvecs = _phase_eigs(
-            eigvals, eigvecs, phasing_track, sort_metric)
+        eigvals, eigvecs = _phase_eigs(eigvals, eigvecs, phasing_track, sort_metric)
 
     return eigvals, eigvecs
 
 
 def cooler_cis_eig(
-        clr,
-        bins,
-        regions=None,
-        n_eigs=3,
-        phasing_track_col='GC',
-        balance='weight',
-        ignore_diags=None,
-        clip_percentile=99.9,
-        sort_metric=None):
+    clr,
+    bins,
+    regions=None,
+    n_eigs=3,
+    phasing_track_col="GC",
+    balance="weight",
+    ignore_diags=None,
+    clip_percentile=99.9,
+    sort_metric=None,
+):
 
     # Perform consitency checks.
     if regions is None:
         chroms_not_in_clr = [
-            chrom for chrom in bins['chrom'].unique()
-            if chrom not in clr.chromsizes]
+            chrom for chrom in bins["chrom"].unique() if chrom not in clr.chromsizes
+        ]
 
         if len(chroms_not_in_clr) > 0:
             raise ValueError(
-                'The following chromosomes are found in the bin table, but not '
-                'in the cooler: '+str(chroms_not_in_clr)
+                "The following chromosomes are found in the bin table, but not "
+                "in the cooler: " + str(chroms_not_in_clr)
             )
 
     if regions is None:
         regions = (
-            [(chrom, 0, clr.chromsizes[chrom])
-             for chrom in bins['chrom'].unique()]
+            [(chrom, 0, clr.chromsizes[chrom]) for chrom in bins["chrom"].unique()]
             if regions is None
             else [bioframe.parse_region(r) for r in regions]
         )
 
     ignore_diags = (
-        clr._load_attrs('bins/weight').get('ignore_diags', 2)
+        clr._load_attrs("bins/weight").get("ignore_diags", 2)
         if ignore_diags is None
-        else ignore_diags)
+        else ignore_diags
+    )
 
     eigvec_table = bins.copy()
     for i in range(n_eigs):
-        eigvec_table['E'+str(i+1)] = np.nan
+        eigvec_table["E" + str(i + 1)] = np.nan
 
     def _each(region):
         A = clr.matrix(balance=balance).fetch(region)
         if phasing_track_col and (phasing_track_col not in bins):
-            raise ValueError('No column "{}" in the bin table'.format(
-                phasing_track_col))
+            raise ValueError(
+                'No column "{}" in the bin table'.format(phasing_track_col)
+            )
         phasing_track = (
             bioframe.slice_bedframe(bins, region)[phasing_track_col].values
-            if phasing_track_col else None)
+            if phasing_track_col
+            else None
+        )
 
         eigvals, eigvecs = cis_eig(
             A,
@@ -333,7 +344,8 @@ def cooler_cis_eig(
             ignore_diags=ignore_diags,
             phasing_track=phasing_track,
             clip_percentile=clip_percentile,
-            sort_metric=sort_metric)
+            sort_metric=sort_metric,
+        )
 
         return eigvals, eigvecs
 
@@ -343,40 +355,44 @@ def cooler_cis_eig(
         lo, hi = bioframe.bisect_bedframe(bins, region)
         for i, eigvec in enumerate(eigvecs):
             eigvec_table.iloc[
-                lo:hi,
-                eigvec_table.columns.get_loc('E'+str(i+1))] = eigvec
+                lo:hi, eigvec_table.columns.get_loc("E" + str(i + 1))
+            ] = eigvec
 
     region_strs = [
-        (chrom
-         if (start == 0 and end == clr.chromsizes[chrom])
-         else '{}:{}-{}'.format(chrom, start, end)
-         )
+        (
+            chrom
+            if (start == 0 and end == clr.chromsizes[chrom])
+            else "{}:{}-{}".format(chrom, start, end)
+        )
         for chrom, start, end in regions
     ]
 
     eigvals = pd.DataFrame(
         index=region_strs,
         data=np.vstack(eigvals_per_reg),
-        columns=['eigval'+str(i+1) for i in range(n_eigs)],
+        columns=["eigval" + str(i + 1) for i in range(n_eigs)],
     )
 
-    eigvals.index.name = 'region'
+    eigvals.index.name = "region"
 
     return eigvals, eigvec_table
 
 
 def cooler_trans_eig(
-        clr, bins,
-        n_eigs=3,
-        partition=None,
-        phasing_track_col='GC',
-        balance='weight',
-        sort_metric=None,
-        **kwargs):
+    clr,
+    bins,
+    n_eigs=3,
+    partition=None,
+    phasing_track_col="GC",
+    balance="weight",
+    sort_metric=None,
+    **kwargs
+):
 
     if partition is None:
         partition = np.r_[
-            [clr.offset(chrom) for chrom in clr.chromnames], len(clr.bins())]
+            [clr.offset(chrom) for chrom in clr.chromnames], len(clr.bins())
+        ]
 
     lo = partition[0]
     hi = partition[-1]
@@ -387,7 +403,8 @@ def cooler_trans_eig(
     if phasing_track_col:
         if phasing_track_col not in bins:
             raise ValueError(
-                'No column "{}" in the bin table'.format(phasing_track_col))
+                'No column "{}" in the bin table'.format(phasing_track_col)
+            )
         phasing_track = bins[phasing_track_col].values[lo:hi]
 
     eigvals, eigvecs = trans_eig(
@@ -396,14 +413,15 @@ def cooler_trans_eig(
         n_eigs=n_eigs,
         phasing_track=phasing_track,
         sort_metric=sort_metric,
-        **kwargs)
+        **kwargs
+    )
 
     eigvec_table = bins.copy()
     for i, eigvec in enumerate(eigvecs):
-        eigvec_table['E{}'.format(i+1)] = eigvec
+        eigvec_table["E{}".format(i + 1)] = eigvec
 
     eigvals = pd.DataFrame(
         data=np.atleast_2d(eigvals),
-        columns=['eigval'+str(i+1) for i in range(n_eigs)],
+        columns=["eigval" + str(i + 1) for i in range(n_eigs)],
     )
     return eigvals, eigvec_table

--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -63,8 +63,10 @@ def cis_eig(
     A, n_eigs=3, phasing_track=None, ignore_diags=2, clip_percentile=0, sort_metric=None
 ):
     """
-    Compute compartment eigenvector on a dense cis matrix
-    Note that the amplitude of compartment eigenvectors is weighted by their corresponding eigenvalue
+    Compute compartment eigenvector on a dense cis matrix.
+
+    Note that the amplitude of compartment eigenvectors is weighted by their
+    corresponding eigenvalue
 
     Parameters
     ----------
@@ -296,7 +298,6 @@ def cooler_cis_eig(
     clip_percentile=99.9,
     sort_metric=None,
 ):
-
     # Perform consitency checks.
     if regions is None:
         chroms_not_in_clr = [

--- a/cooltools/expected.py
+++ b/cooltools/expected.py
@@ -35,9 +35,9 @@ def contact_areas(distbins, region1, region2):
             start1, start2 = start2, start1
             end1, end2 = end2, end1
         areas = (
-            _contact_areas(distbins, end2 - start1) -
-            _contact_areas(distbins, start2 - start1) -
-            _contact_areas(distbins, end2 - end1)
+            _contact_areas(distbins, end2 - start1)
+            - _contact_areas(distbins, start2 - start1)
+            - _contact_areas(distbins, end2 - end1)
         )
         if end1 < start2:
             areas += _contact_areas(distbins, start2 - end1)
@@ -45,10 +45,7 @@ def contact_areas(distbins, region1, region2):
     return areas
 
 
-def compute_scaling(df, region1, region2=None,
-                    dmin=int(1e1),
-                    dmax=int(1e7),
-                    n_bins=50):
+def compute_scaling(df, region1, region2=None, dmin=int(1e1), dmax=int(1e7), n_bins=50):
 
     import dask.array as da
 
@@ -59,21 +56,17 @@ def compute_scaling(df, region1, region2=None,
     areas = contact_areas(distbins, region1, region2)
 
     df = df[
-        (df['pos1'] >= region1[0]) &
-        (df['pos1'] < region1[1]) &
-        (df['pos2'] >= region2[0]) &
-        (df['pos2'] < region2[1])
+        (df["pos1"] >= region1[0])
+        & (df["pos1"] < region1[1])
+        & (df["pos2"] >= region2[0])
+        & (df["pos2"] < region2[1])
     ]
-    dists = (df['pos2'] - df['pos1']).values
+    dists = (df["pos2"] - df["pos1"]).values
 
     if isinstance(dists, da.Array):
-        obs, _ = da.histogram(
-            dists[(dists >= dmin) & (dists < dmax)],
-            bins=distbins)
+        obs, _ = da.histogram(dists[(dists >= dmin) & (dists < dmax)], bins=distbins)
     else:
-        obs, _ = np.histogram(
-            dists[(dists >= dmin) & (dists < dmax)],
-            bins=distbins)
+        obs, _ = np.histogram(dists[(dists >= dmin) & (dists < dmax)], bins=distbins)
 
     return distbins, obs, areas
 
@@ -90,12 +83,14 @@ def bg2slice_frame(bg2, region1, region2):
         end1 = np.inf
     if end2 is None:
         end2 = np.inf
-    out = bg2[(bg2['chrom1'] == chrom1) &
-              (bg2['start1'] >= start1) &
-              (bg2['end1'] < end1) &
-              (bg2['chrom2'] == chrom2) &
-              (bg2['start2'] >= start2) &
-              (bg2['end2'] < end2)]
+    out = bg2[
+        (bg2["chrom1"] == chrom1)
+        & (bg2["start1"] >= start1)
+        & (bg2["end1"] < end1)
+        & (bg2["chrom2"] == chrom2)
+        & (bg2["start2"] >= start2)
+        & (bg2["end2"] < end2)
+    ]
     return out
 
 
@@ -128,7 +123,7 @@ def lattice_pdist_frequencies(n, points):
         raise ValueError("Integers must be distinct.")
     x = np.zeros(n)
     x[points] = 1
-    return np.round(fftconvolve(x, x[::-1], mode='full')).astype(int)[-n:]
+    return np.round(fftconvolve(x, x[::-1], mode="full")).astype(int)[-n:]
 
 
 def count_bad_pixels_per_diag(n, bad_bins):
@@ -200,11 +195,11 @@ def count_bad_pixels_per_diag(n, bad_bins):
                 if pl == k:
                     break
         if pr > 0:
-            while (bad_bins[pr-1] + diag) >= n:
+            while (bad_bins[pr - 1] + diag) >= n:
                 pr -= 1
                 if pr == 0:
                     break
-        dcount[diag] = 2*k - ixn[diag] - pl - (k - pr)
+        dcount[diag] = 2 * k - ixn[diag] - pl - (k - pr)
     return dcount
 
 
@@ -249,11 +244,11 @@ def make_diag_table(bad_mask, span1, span2):
         Table indexed by 'diag' with columns ['n_elem', 'n_bad'].
 
     """
+
     def _make_diag_table(n_bins, bad_locs):
-        diags = pd.DataFrame(index=pd.Series(np.arange(n_bins), name='diag'))
-        diags['n_elem'] = count_all_pixels_per_diag(n_bins)
-        diags['n_valid'] = (diags['n_elem'] -
-                            count_bad_pixels_per_diag(n_bins, bad_locs))
+        diags = pd.DataFrame(index=pd.Series(np.arange(n_bins), name="diag"))
+        diags["n_elem"] = count_all_pixels_per_diag(n_bins)
+        diags["n_valid"] = diags["n_elem"] - count_bad_pixels_per_diag(n_bins, bad_locs)
         return diags
 
     if span1 == span2:
@@ -267,28 +262,32 @@ def make_diag_table(bad_mask, span1, span2):
             hi1, hi2 = hi2, hi1
         diags = (
             _make_diag_table(hi2 - lo1, where(bad_mask[lo1:hi2]))
-            .subtract(_make_diag_table(lo2 - lo1, where(bad_mask[lo1:lo2])),
-                      fill_value=0)
-            .subtract(_make_diag_table(hi2 - hi1, where(bad_mask[hi1:hi2])),
-                      fill_value=0)
+            .subtract(
+                _make_diag_table(lo2 - lo1, where(bad_mask[lo1:lo2])), fill_value=0
+            )
+            .subtract(
+                _make_diag_table(hi2 - hi1, where(bad_mask[hi1:hi2])), fill_value=0
+            )
         )
         if hi1 < lo2:
-            diags.add(_make_diag_table(lo2 - hi1, where(bad_mask[hi1:lo2])),
-                      fill_value=0)
-        diags = diags[diags['n_elem'] > 0]
+            diags.add(
+                _make_diag_table(lo2 - hi1, where(bad_mask[hi1:lo2])), fill_value=0
+            )
+        diags = diags[diags["n_elem"] > 0]
 
-    diags = diags.drop('n_elem', axis=1)
+    diags = diags.drop("n_elem", axis=1)
     return diags.astype(int)
 
 
 def _sum_diagonals(df, field):
-    reduced = df.groupby('diag')[field].sum()
-    reduced.name = field + '.sum'
+    reduced = df.groupby("diag")[field].sum()
+    reduced.name = field + ".sum"
     return reduced
 
 
-def cis_expected(clr, regions, field='balanced', chunksize=1000000,
-                 use_dask=True, ignore_diags=2):
+def cis_expected(
+    clr, regions, field="balanced", chunksize=1000000, use_dask=True, ignore_diags=2
+):
     """
     Compute the mean signal along diagonals of one or more regional blocks of
     intra-chromosomal contact matrices. Typically used as a background model
@@ -316,7 +315,7 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
     from cooler.sandbox.dask import read_table
 
     if use_dask:
-        pixels = read_table(clr.uri + '/pixels', chunksize=chunksize)
+        pixels = read_table(clr.uri + "/pixels", chunksize=chunksize)
     else:
         pixels = clr.pixels()[:]
     pixels = cooler.annotate(pixels, clr.bins(), replace=False)
@@ -325,9 +324,9 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
     named_regions = False
     if isinstance(regions, pd.DataFrame):
         named_regions = True
-        chroms = regions['chrom'].values
-        names = regions['name'].values
-        regions = regions[['chrom', 'start', 'end']].to_records(index=False)
+        chroms = regions["chrom"].values
+        names = regions["name"].values
+        regions = regions[["chrom", "start", "end"]].to_records(index=False)
     else:
         chroms = [region[0] for region in regions]
         names = chroms
@@ -338,7 +337,7 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
 
     for region in regions:
         if len(region) == 1:
-            chrom, = region
+            (chrom,) = region
             start1, end1 = 0, clr.chromsizes[chrom]
             start2, end2 = start1, end1
         elif len(region) == 3:
@@ -350,7 +349,7 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
             raise ValueError("Regions must be sequences of length 1, 3 or 5")
 
         bins = clr.bins().fetch(chrom).reset_index(drop=True)
-        bad_mask = np.array(bins['weight'].isnull())
+        bad_mask = np.array(bins["weight"].isnull())
         lo1, hi1 = clr.extent((chrom, start1, end1))
         lo2, hi2 = clr.extent((chrom, start2, end2))
         co = clr.offset(chrom)
@@ -361,12 +360,10 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
 
         dt = make_diag_table(bad_mask, [lo1, hi1], [lo2, hi2])
         sel = bg2slice_frame(
-            cis_maps[chrom],
-            (chrom, start1, end1),
-            (chrom, start2, end2)
+            cis_maps[chrom], (chrom, start1, end1), (chrom, start2, end2)
         ).copy()
-        sel['diag'] = sel['bin2_id'] - sel['bin1_id']
-        sel['balanced'] = sel['count'] * sel['weight1'] * sel['weight2']
+        sel["diag"] = sel["bin2_id"] - sel["bin1_id"]
+        sel["balanced"] = sel["count"] * sel["weight1"] * sel["weight2"]
         agg = _sum_diagonals(sel, field)
         diag_tables.append(dt)
         data_sums.append(agg)
@@ -384,17 +381,13 @@ def cis_expected(clr, regions, field='balanced', chunksize=1000000,
     # merge and return
     if named_regions:
         dtable = pd.concat(
-            diag_tables,
-            keys=zip(names, chroms),
-            names=['name', 'chrom'])
+            diag_tables, keys=zip(names, chroms), names=["name", "chrom"]
+        )
     else:
-        dtable = pd.concat(
-            diag_tables,
-            keys=list(chroms),
-            names=['chrom'])
+        dtable = pd.concat(diag_tables, keys=list(chroms), names=["chrom"])
 
     # the actual expected is balanced.sum/n_valid:
-    dtable['balanced.avg'] = dtable['balanced.sum'] / dtable['n_valid']
+    dtable["balanced.avg"] = dtable["balanced.sum"] / dtable["n_valid"]
     return dtable
 
 
@@ -424,82 +417,76 @@ def trans_expected(clr, chromosomes, chunksize=1000000, use_dask=False):
     the actual value of expected for every interchromosomal pair.
 
     """
+
     def n_total_trans_elements(clr, chromosomes):
         n = len(chromosomes)
-        x = [clr.extent(chrom)[1] - clr.extent(chrom)[0]
-             for chrom in chromosomes]
+        x = [clr.extent(chrom)[1] - clr.extent(chrom)[0] for chrom in chromosomes]
         pairblock_list = []
         for i in range(n):
             for j in range(i + 1, n):
                 # appending to the list of tuples
-                pairblock_list.append((chromosomes[i],
-                                       chromosomes[j],
-                                       x[i] * x[j]))
-        return pd.DataFrame(pairblock_list,
-                            columns=['chrom1', 'chrom2', 'n_total'])
+                pairblock_list.append((chromosomes[i], chromosomes[j], x[i] * x[j]))
+        return pd.DataFrame(pairblock_list, columns=["chrom1", "chrom2", "n_total"])
 
     def n_bad_trans_elements(clr, chromosomes):
         n = 0
         # bad bins are ones with
         # the weight vector being NaN:
-        x = [np.sum(clr.bins()['weight']
-                       .fetch(chrom)
-                       .isnull()
-                       .astype(int)
-                       .values)
-             for chrom in chromosomes]
+        x = [
+            np.sum(clr.bins()["weight"].fetch(chrom).isnull().astype(int).values)
+            for chrom in chromosomes
+        ]
         pairblock_list = []
         for i in range(len(x)):
             for j in range(i + 1, len(x)):
                 # appending to the list of tuples
-                pairblock_list.append((chromosomes[i],
-                                       chromosomes[j],
-                                       x[i] * x[j]))
-        return pd.DataFrame(pairblock_list,
-                            columns=['chrom1', 'chrom2', 'n_bad'])
+                pairblock_list.append((chromosomes[i], chromosomes[j], x[i] * x[j]))
+        return pd.DataFrame(pairblock_list, columns=["chrom1", "chrom2", "n_bad"])
 
     if use_dask:
         # pixels = daskify(clr.filename, clr.root + '/pixels', chunksize=chunksize)
-        raise NotImplementedError(
-            "To be implemented once dask supports MultiIndex")
+        raise NotImplementedError("To be implemented once dask supports MultiIndex")
     else:
         pixels = clr.pixels()[:]
     # getting pixels that belong to trans-area,
     # defined by the list of chromosomes:
     pixels = cooler.annotate(pixels, clr.bins(), replace=False)
     pixels = pixels[
-        (pixels.chrom1.isin(chromosomes)) &
-        (pixels.chrom2.isin(chromosomes)) &
-        (pixels.chrom1 != pixels.chrom2)
+        (pixels.chrom1.isin(chromosomes))
+        & (pixels.chrom2.isin(chromosomes))
+        & (pixels.chrom1 != pixels.chrom2)
     ]
-    pixels['balanced'] = pixels['count'] * \
-        pixels['weight1'] * pixels['weight2']
-    ntot = n_total_trans_elements(clr, chromosomes).groupby(
-        ('chrom1', 'chrom2'))['n_total'].sum()
-    nbad = n_bad_trans_elements(clr, chromosomes).groupby(
-        ('chrom1', 'chrom2'))['n_bad'].sum()
+    pixels["balanced"] = pixels["count"] * pixels["weight1"] * pixels["weight2"]
+    ntot = (
+        n_total_trans_elements(clr, chromosomes)
+        .groupby(("chrom1", "chrom2"))["n_total"]
+        .sum()
+    )
+    nbad = (
+        n_bad_trans_elements(clr, chromosomes)
+        .groupby(("chrom1", "chrom2"))["n_bad"]
+        .sum()
+    )
     trans_area = ntot - nbad
-    trans_area.name = 'n_valid'
+    trans_area.name = "n_valid"
     # processing with use_dask=True is different:
     if use_dask:
         # trans_sum = pixels.groupby(['chrom1', 'chrom2'])['balanced'].sum().compute()
         pass
     else:
-        trans_sum = pixels.groupby(['chrom1', 'chrom2'])['balanced'].sum()
+        trans_sum = pixels.groupby(["chrom1", "chrom2"])["balanced"].sum()
     # for consistency with the cis_expected function:
-    trans_sum.name = trans_sum.name + '.sum'
+    trans_sum.name = trans_sum.name + ".sum"
 
     # returning a DataFrame with MultiIndex, that stores
     # pairs of 'balanced.sum' and 'n_valid' values for each
     # pair of chromosomes.
     dtable = pd.merge(
-        trans_sum.to_frame(),
-        trans_area.to_frame(),
-        left_index=True,
-        right_index=True)
+        trans_sum.to_frame(), trans_area.to_frame(), left_index=True, right_index=True
+    )
 
     # the actual expected is balanced.sum/n_valid:
-    dtable['balanced.avg'] = dtable['balanced.sum'] / dtable['n_valid']
+    dtable["balanced.avg"] = dtable["balanced.sum"] / dtable["n_valid"]
     return dtable
 
 
@@ -509,14 +496,16 @@ def trans_expected(clr, chromosomes, chunksize=1000000, use_dask=False):
 def make_diag_tables(clr, supports):
 
     bins = clr.bins()[:]
-    if 'weight' in clr.bins().columns:
-        groups = dict(iter(bins.groupby('chrom')['weight']))
-        bad_bin_dict = {chrom: np.array(groups[chrom].isnull())
-                        for chrom in groups.keys()}
+    if "weight" in clr.bins().columns:
+        groups = dict(iter(bins.groupby("chrom")["weight"]))
+        bad_bin_dict = {
+            chrom: np.array(groups[chrom].isnull()) for chrom in groups.keys()
+        }
     else:
-        sizes = dict(bins.groupby('chrom').size())
-        bad_bin_dict = {chrom: np.zeros(sizes[chrom], dtype=bool)
-                        for chrom in sizes.keys()}
+        sizes = dict(bins.groupby("chrom").size())
+        bad_bin_dict = {
+            chrom: np.zeros(sizes[chrom], dtype=bool) for chrom in sizes.keys()
+        }
 
     where = np.flatnonzero
     diag_tables = {}
@@ -524,7 +513,7 @@ def make_diag_tables(clr, supports):
         if isinstance(region, str):
             region = bioframe.parse_region(region)
         if len(region) == 1:
-            chrom, = region
+            (chrom,) = region
             start1, end1 = 0, clr.chromsizes[chrom]
             start2, end2 = start1, end1
         elif len(region) == 2:
@@ -558,16 +547,17 @@ def _diagsum_symm(clr, fields, transforms, supports, span):
     pixels = clr.pixels()[lo:hi]
     pixels = cooler.annotate(pixels, bins, replace=False)
 
-    pixels = pixels[pixels['chrom1'] == pixels['chrom2']].copy()
-    pixels['diag'] = pixels['bin2_id'] - pixels['bin1_id']
+    pixels = pixels[pixels["chrom1"] == pixels["chrom2"]].copy()
+    pixels["diag"] = pixels["bin2_id"] - pixels["bin1_id"]
     for field, t in transforms.items():
         pixels[field] = t(pixels)
 
-    pixels['support'] = assign_supports(pixels, supports, suffix='1')
+    pixels["support"] = assign_supports(pixels, supports, suffix="1")
 
-    pixel_groups = dict(iter(pixels.groupby('support')))
-    return {int(i): group.groupby('diag')[fields].sum()
-            for i, group in pixel_groups.items()}
+    pixel_groups = dict(iter(pixels.groupby("support")))
+    return {
+        int(i): group.groupby("diag")[fields].sum() for i, group in pixel_groups.items()
+    }
 
 
 def _diagsum_asymm(clr, fields, transforms, contact_type, supports1, supports2, span):
@@ -576,21 +566,23 @@ def _diagsum_asymm(clr, fields, transforms, contact_type, supports1, supports2, 
     pixels = clr.pixels()[lo:hi]
     pixels = cooler.annotate(pixels, bins, replace=False)
 
-    if contact_type == 'cis':
-        pixels = pixels[pixels['chrom1'] == pixels['chrom2']].copy()
-    elif contact_type == 'trans':
-        pixels = pixels[pixels['chrom1'] != pixels['chrom2']].copy()
+    if contact_type == "cis":
+        pixels = pixels[pixels["chrom1"] == pixels["chrom2"]].copy()
+    elif contact_type == "trans":
+        pixels = pixels[pixels["chrom1"] != pixels["chrom2"]].copy()
 
-    pixels['diag'] = pixels['bin2_id'] - pixels['bin1_id']
+    pixels["diag"] = pixels["bin2_id"] - pixels["bin1_id"]
     for field, t in transforms.items():
         pixels[field] = t(pixels)
 
-    pixels['support1'] = assign_supports(pixels, supports1, suffix='1')
-    pixels['support2'] = assign_supports(pixels, supports1, suffix='2')
+    pixels["support1"] = assign_supports(pixels, supports1, suffix="1")
+    pixels["support2"] = assign_supports(pixels, supports1, suffix="2")
 
-    pixel_groups = dict(iter(pixels.groupby(['support1', 'support2'])))
-    return {(int(i), int(j)): group.groupby('diag')[fields].sum()
-            for (i, j), group in pixel_groups.items()}
+    pixel_groups = dict(iter(pixels.groupby(["support1", "support2"])))
+    return {
+        (int(i), int(j)): group.groupby("diag")[fields].sum()
+        for (i, j), group in pixel_groups.items()
+    }
 
 
 def _blocksum_asymm(clr, fields, transforms, supports1, supports2, span):
@@ -599,21 +591,23 @@ def _blocksum_asymm(clr, fields, transforms, supports1, supports2, span):
     pixels = clr.pixels()[lo:hi]
     pixels = cooler.annotate(pixels, bins, replace=False)
 
-    pixels = pixels[pixels['chrom1'] != pixels['chrom2']].copy()
+    pixels = pixels[pixels["chrom1"] != pixels["chrom2"]].copy()
     for field, t in transforms.items():
         pixels[field] = t(pixels)
 
-    pixels['support1'] = assign_supports(pixels, supports1, suffix='1')
-    pixels['support2'] = assign_supports(pixels, supports2, suffix='2')
+    pixels["support1"] = assign_supports(pixels, supports1, suffix="1")
+    pixels["support2"] = assign_supports(pixels, supports2, suffix="2")
     pixels = pixels.dropna()
 
-    pixel_groups = dict(iter(pixels.groupby(['support1', 'support2'])))
-    return {(int(i), int(j)): group[fields].sum()
-            for (i, j), group in pixel_groups.items()}
+    pixel_groups = dict(iter(pixels.groupby(["support1", "support2"])))
+    return {
+        (int(i), int(j)): group[fields].sum() for (i, j), group in pixel_groups.items()
+    }
 
 
-def diagsum(clr, supports, transforms=None, chunksize=10000000, ignore_diags=2,
-            map=map):
+def diagsum(
+    clr, supports, transforms=None, chunksize=10000000, ignore_diags=2, map=map
+):
     """
 
     Intra-chromosomal diagonal summary statistics.
@@ -641,12 +635,12 @@ def diagsum(clr, supports, transforms=None, chunksize=10000000, ignore_diags=2,
 
     """
     spans = partition(0, len(clr.pixels()), chunksize)
-    fields = ['count'] + list(transforms.keys())
+    fields = ["count"] + list(transforms.keys())
     dtables = make_diag_tables(clr, supports)
 
     for dt in dtables.values():
         for field in fields:
-            agg_name = '{}.sum'.format(field)
+            agg_name = "{}.sum".format(field)
             dt[agg_name] = 0
 
     job = partial(_diagsum_symm, clr, fields, transforms, supports)
@@ -655,22 +649,31 @@ def diagsum(clr, supports, transforms=None, chunksize=10000000, ignore_diags=2,
         for i, agg in result.items():
             support = supports[i]
             for field in fields:
-                agg_name = '{}.sum'.format(field)
-                dtables[support][agg_name] = \
-                    dtables[support][agg_name].add(agg[field], fill_value=0)
+                agg_name = "{}.sum".format(field)
+                dtables[support][agg_name] = dtables[support][agg_name].add(
+                    agg[field], fill_value=0
+                )
 
     if ignore_diags:
         for dt in dtables.values():
             for field in fields:
-                agg_name = '{}.sum'.format(field)
+                agg_name = "{}.sum".format(field)
                 j = dt.columns.get_loc(agg_name)
                 dt.iloc[:ignore_diags, j] = np.nan
 
     return dtables
 
 
-def diagsum_asymm(clr, supports1, supports2, contact_type='cis',
-                  transforms=None, chunksize=10000000, ignore_diags=2, map=map):
+def diagsum_asymm(
+    clr,
+    supports1,
+    supports2,
+    contact_type="cis",
+    transforms=None,
+    chunksize=10000000,
+    ignore_diags=2,
+    map=map,
+):
     """
 
     Intra-chromosomal diagonal summary statistics.
@@ -698,32 +701,33 @@ def diagsum_asymm(clr, supports1, supports2, contact_type='cis',
 
     """
     spans = partition(0, len(clr.pixels()), chunksize)
-    fields = ['count'] + list(transforms.keys())
+    fields = ["count"] + list(transforms.keys())
     areas = list(zip(supports1, supports2))
     dtables = make_diag_tables(clr, areas)
 
     for dt in dtables.values():
         for field in fields:
-            agg_name = '{}.sum'.format(field)
+            agg_name = "{}.sum".format(field)
             dt[agg_name] = 0
 
-    job = partial(_diagsum_asymm, clr, fields, transforms,
-                  contact_type, supports1, supports2)
+    job = partial(
+        _diagsum_asymm, clr, fields, transforms, contact_type, supports1, supports2
+    )
     results = map(job, spans)
     for result in results:
         for (i, j), agg in result.items():
             support1 = supports1[i]
             support2 = supports2[j]
             for field in fields:
-                agg_name = '{}.sum'.format(field)
-                dtables[support1, support2][agg_name] = \
-                    dtables[support1, support2][agg_name].add(
-                        agg[field], fill_value=0)
+                agg_name = "{}.sum".format(field)
+                dtables[support1, support2][agg_name] = dtables[support1, support2][
+                    agg_name
+                ].add(agg[field], fill_value=0)
 
     if ignore_diags:
         for dt in dtables.values():
             for field in fields:
-                agg_name = '{}.sum'.format(field)
+                agg_name = "{}.sum".format(field)
                 j = dt.columns.get_loc(agg_name)
                 dt.iloc[:ignore_diags, j] = np.nan
 
@@ -755,10 +759,10 @@ def blocksum_pairwise(clr, supports, transforms=None, chunksize=1000000, map=map
     dict of support region -> (field name -> summary)
 
     """
+
     def n_total_block_elements(clr, supports):
         n = len(supports)
-        x = [clr.extent(region)[1] - clr.extent(region)[0]
-             for region in supports]
+        x = [clr.extent(region)[1] - clr.extent(region)[0] for region in supports]
         blocks = {}
         for i in range(n):
             for j in range(i + 1, n):
@@ -769,12 +773,10 @@ def blocksum_pairwise(clr, supports, transforms=None, chunksize=1000000, map=map
         n = 0
         # bad bins are ones with
         # the weight vector being NaN:
-        x = [np.sum(clr.bins()['weight']
-                       .fetch(region)
-                       .isnull()
-                       .astype(int)
-                       .values)
-             for region in supports]
+        x = [
+            np.sum(clr.bins()["weight"].fetch(region).isnull().astype(int).values)
+            for region in supports
+        ]
         blocks = {}
         for i in range(len(x)):
             for j in range(i + 1, len(x)):
@@ -784,21 +786,20 @@ def blocksum_pairwise(clr, supports, transforms=None, chunksize=1000000, map=map
     blocks = list(combinations(supports, 2))
     supports1, supports2 = list(zip(*blocks))
     spans = partition(0, len(clr.pixels()), chunksize)
-    fields = ['count'] + list(transforms.keys())
+    fields = ["count"] + list(transforms.keys())
 
     n_tot = n_total_block_elements(clr, supports)
     n_bad = n_bad_block_elements(clr, supports)
     records = {(c1, c2): defaultdict(int) for (c1, c2) in blocks}
     for c1, c2 in blocks:
-        records[c1, c2]['n_valid'] = n_tot[c1, c2] - n_bad[c1, c2]
+        records[c1, c2]["n_valid"] = n_tot[c1, c2] - n_bad[c1, c2]
 
-    job = partial(_blocksum_asymm, clr, fields,
-                  transforms, supports1, supports2)
+    job = partial(_blocksum_asymm, clr, fields, transforms, supports1, supports2)
     results = map(job, spans)
     for result in results:
         for (i, j), agg in result.items():
             for field in fields:
-                agg_name = '{}.sum'.format(field)
+                agg_name = "{}.sum".format(field)
                 s = np.asscalar(agg[field])
                 if not np.isnan(s):
                     records[supports1[i], supports2[j]][agg_name] += s

--- a/cooltools/insulation.py
+++ b/cooltools/insulation.py
@@ -20,7 +20,7 @@ def get_n_pixels(bad_bin_mask, window=10, ignore_diags=2):
     loc_bad_bin_mask = np.zeros(N, dtype=bool)
     for i_shift in range(0, window):
         for j_shift in range(0, window):
-            if i_shift+j_shift < ignore_diags:
+            if i_shift + j_shift < ignore_diags:
                 continue
 
             loc_bad_bin_mask[:] = False
@@ -33,13 +33,13 @@ def get_n_pixels(bad_bin_mask, window=10, ignore_diags=2):
             else:
                 loc_bad_bin_mask[:-j_shift] |= bad_bin_mask[j_shift:]
 
-            n_pixels[i_shift:(-j_shift if j_shift else None)] += (
-                1 - loc_bad_bin_mask[i_shift:(-j_shift if j_shift else None)])
+            n_pixels[i_shift : (-j_shift if j_shift else None)] += (
+                1 - loc_bad_bin_mask[i_shift : (-j_shift if j_shift else None)]
+            )
     return n_pixels
 
 
-def insul_diamond(pixel_query, bins, window=10, ignore_diags=2, 
-                  norm_by_median=True):
+def insul_diamond(pixel_query, bins, window=10, ignore_diags=2, norm_by_median=True):
     """
     Calculates the insulation score of a Hi-C interaction matrix.
     Parameters
@@ -66,45 +66,44 @@ def insul_diamond(pixel_query, bins, window=10, ignore_diags=2,
     N = hi_bin_id - lo_bin_id
     sum_counts = np.zeros(N)
     sum_balanced = np.zeros(N)
-    
-    n_pixels = get_n_pixels(bins.weight.isnull().values, 
-                            window=window, 
-                            ignore_diags=ignore_diags)
-    
-    
+
+    n_pixels = get_n_pixels(
+        bins.weight.isnull().values, window=window, ignore_diags=ignore_diags
+    )
+
     for chunk_dict in pixel_query.read_chunked():
-        chunk = pd.DataFrame(chunk_dict, columns=[
-                             'bin1_id', 'bin2_id', 'count'])
+        chunk = pd.DataFrame(chunk_dict, columns=["bin1_id", "bin2_id", "count"])
         diag_pixels = chunk[chunk.bin2_id - chunk.bin1_id <= (window - 1) * 2]
-        
-        diag_pixels = cooler.annotate(diag_pixels, bins[['weight']])
-        diag_pixels['balanced'] = (
-            diag_pixels['count'] 
-            * diag_pixels['weight1'] 
-            * diag_pixels['weight2']
+
+        diag_pixels = cooler.annotate(diag_pixels, bins[["weight"]])
+        diag_pixels["balanced"] = (
+            diag_pixels["count"] * diag_pixels["weight1"] * diag_pixels["weight2"]
         )
-        valid_pixel_mask = ~diag_pixels['balanced'].isnull().values
+        valid_pixel_mask = ~diag_pixels["balanced"].isnull().values
 
         i = diag_pixels.bin1_id.values - lo_bin_id
         j = diag_pixels.bin2_id.values - lo_bin_id
 
         for i_shift in range(0, window):
             for j_shift in range(0, window):
-                if i_shift+j_shift < ignore_diags:
+                if i_shift + j_shift < ignore_diags:
                     continue
-                    
-                mask = ((i + i_shift == j - j_shift) &
-                        (i + i_shift < N) & (j - j_shift >= 0))
+
+                mask = (
+                    (i + i_shift == j - j_shift)
+                    & (i + i_shift < N)
+                    & (j - j_shift >= 0)
+                )
 
                 sum_counts += np.bincount(
-                    i[mask] + i_shift,
-                    diag_pixels['count'].values[mask], 
-                    minlength=N)
-                
+                    i[mask] + i_shift, diag_pixels["count"].values[mask], minlength=N
+                )
+
                 sum_balanced += np.bincount(
-                    i[mask & valid_pixel_mask] + i_shift, 
-                    diag_pixels['balanced'].values[mask & valid_pixel_mask], 
-                    minlength=N)
+                    i[mask & valid_pixel_mask] + i_shift,
+                    diag_pixels["balanced"].values[mask & valid_pixel_mask],
+                    minlength=N,
+                )
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -125,7 +124,7 @@ def calculate_insulation_score(
     append_raw_scores=False,
     verbose=False,
 ):
-    '''Calculate the diamond insulation scores and call insulating boundaries.
+    """Calculate the diamond insulation scores and call insulating boundaries.
     Parameters
     ----------
     clr : cooler.Cooler
@@ -148,14 +147,16 @@ def calculate_insulation_score(
     ins_table : pandas.DataFrame
         A table containing the insulation scores of the genomic bins and
         the insulating boundary strengths.
-    '''
+    """
     if chromosomes is None:
         chromosomes = clr.chromnames
 
-    bin_size = clr.info['bin-size']
-    ignore_diags = (ignore_diags
-                    if ignore_diags is not None
-                    else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'])
+    bin_size = clr.info["bin-size"]
+    ignore_diags = (
+        ignore_diags
+        if ignore_diags is not None
+        else clr._load_attrs(clr.root.rstrip("/") + "/bins/weight")["ignore_diags"]
+    )
 
     if isinstance(window_bp, int):
         window_bp = [window_bp]
@@ -165,25 +166,25 @@ def calculate_insulation_score(
     bad_win_sizes = window_bp % bin_size != 0
     if np.any(bad_win_sizes):
         raise Exception(
-            'The window sizes {} has to be a multiple of the bin size {}'.format(
-                window_bp[bad_win_sizes], bin_size))
+            "The window sizes {} has to be a multiple of the bin size {}".format(
+                window_bp[bad_win_sizes], bin_size
+            )
+        )
 
     # XXX -- Use a delayed query executor
     nbins = len(clr.bins())
     selector = CSRSelector(
-        clr.open('r'),
-        shape=(nbins, nbins),
-        field='count',
-        chunksize=10000000)
+        clr.open("r"), shape=(nbins, nbins), field="count", chunksize=10000000
+    )
 
     ins_chrom_tables = []
     for chrom in chromosomes:
         if verbose:
-            logging.info('Processing {}'.format(chrom))
-            
+            logging.info("Processing {}".format(chrom))
+
         chrom_bins = clr.bins().fetch(chrom)
-        ins_chrom = chrom_bins[['chrom', 'start', 'end']].copy()
-        ins_chrom['is_bad_bin'] = chrom_bins['weight'].isnull()
+        ins_chrom = chrom_bins[["chrom", "start", "end"]].copy()
+        ins_chrom["is_bad_bin"] = chrom_bins["weight"].isnull()
 
         # XXX --- Create a delayed selection
         c0, c1 = clr.extent(chrom)
@@ -192,22 +193,25 @@ def calculate_insulation_score(
         for j, win_bin in enumerate(window_bins):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
-                ins_track, n_pixels, sum_balanced, sum_counts = insul_diamond(  # XXX -- updated insul_diamond
-                    chrom_query,
-                    chrom_bins,
-                    window=win_bin,
-                    ignore_diags=ignore_diags)
+                (
+                    ins_track,
+                    n_pixels,
+                    sum_balanced,
+                    sum_counts,
+                ) = insul_diamond(  # XXX -- updated insul_diamond
+                    chrom_query, chrom_bins, window=win_bin, ignore_diags=ignore_diags
+                )
                 ins_track[ins_track == 0] = np.nan
                 ins_track = np.log2(ins_track)
 
             ins_track[~np.isfinite(ins_track)] = np.nan
 
-            ins_chrom['log2_insulation_score_{}'.format(window_bp[j])] = ins_track
-            ins_chrom['n_valid_pixels_{}'.format(window_bp[j])] = n_pixels
-            
+            ins_chrom["log2_insulation_score_{}".format(window_bp[j])] = ins_track
+            ins_chrom["n_valid_pixels_{}".format(window_bp[j])] = n_pixels
+
             if append_raw_scores:
-                ins_chrom['sum_counts_{}'.format(window_bp[j])] = sum_counts
-                ins_chrom['sum_balanced_{}'.format(window_bp[j])] = sum_balanced
+                ins_chrom["sum_counts_{}".format(window_bp[j])] = sum_counts
+                ins_chrom["sum_balanced_{}".format(window_bp[j])] = sum_balanced
 
         ins_chrom_tables.append(ins_chrom)
 
@@ -219,12 +223,11 @@ def find_boundaries(
     ins_table,
     min_frac_valid_pixels=0.66,
     min_dist_bad_bin=0,
-    log2_ins_key = 'log2_insulation_score_{WINDOW}',
-    n_valid_pixels_key = 'n_valid_pixels_{WINDOW}',
-    is_bad_bin_key = 'is_bad_bin'
-    
+    log2_ins_key="log2_insulation_score_{WINDOW}",
+    n_valid_pixels_key="n_valid_pixels_{WINDOW}",
+    is_bad_bin_key="is_bad_bin",
 ):
-    '''Call insulating boundaries.
+    """Call insulating boundaries.
     Find all local minima of the log2(insulation score) and calculate their 
     chromosome-wide topographic prominence.
     
@@ -250,48 +253,56 @@ def find_boundaries(
     -------
     ins_table : pandas.DataFrame
         A bin table with appended columns with boundary prominences.
-    '''
-    
+    """
+
     if min_dist_bad_bin:
-        ins_table = pd.concat([
-            df.assign(dist_bad_bin = numutils.dist_to_mask(df.is_bad_bin))
-            for chrom,df in ins_table.groupby('chrom')])
-        
-    if '{WINDOW}' in log2_ins_key:
+        ins_table = pd.concat(
+            [
+                df.assign(dist_bad_bin=numutils.dist_to_mask(df.is_bad_bin))
+                for chrom, df in ins_table.groupby("chrom")
+            ]
+        )
+
+    if "{WINDOW}" in log2_ins_key:
         windows = set()
         for col in ins_table.columns:
-            m = re.match(log2_ins_key.format(WINDOW='(\d+)'), col)
+            m = re.match(log2_ins_key.format(WINDOW="(\d+)"), col)
             if m:
                 windows.add(int(m.groups()[0]))
     else:
         windows = set([None])
-        
+
     min_valid_pixels = {
-        win:ins_table[n_valid_pixels_key.format(WINDOW=win)].max()*min_frac_valid_pixels
-        for win in windows}
-    
+        win: ins_table[n_valid_pixels_key.format(WINDOW=win)].max()
+        * min_frac_valid_pixels
+        for win in windows
+    }
+
     dfs = []
-    for chrom, df in ins_table.groupby('chrom'):
+    for chrom, df in ins_table.groupby("chrom"):
         df = df.reset_index(drop=True)
         for win in windows:
-            mask = (df[n_valid_pixels_key.format(WINDOW=win)].values >= min_valid_pixels[win])
-            
+            mask = (
+                df[n_valid_pixels_key.format(WINDOW=win)].values
+                >= min_valid_pixels[win]
+            )
+
             if min_dist_bad_bin:
-                mask &= (df.dist_bad_bin.values >= min_dist_bad_bin)
-            
+                mask &= df.dist_bad_bin.values >= min_dist_bad_bin
+
             ins_track = df[log2_ins_key.format(WINDOW=win)].values[mask]
             poss, proms = peaks.find_peak_prominence(-ins_track)
             ins_prom_track = np.zeros_like(ins_track) * np.nan
             ins_prom_track[poss] = proms
-            
+
             if win is not None:
-                bs_key = 'boundary_strength_{win}'.format(win=win) 
+                bs_key = "boundary_strength_{win}".format(win=win)
             else:
-                bs_key = 'boundary_strength'
-                
+                bs_key = "boundary_strength"
+
             df[bs_key] = np.nan
             df.loc[mask, bs_key] = ins_prom_track
-            
+
         dfs.append(df)
     return pd.concat(dfs)
 
@@ -319,9 +330,9 @@ def _insul_diamond_dense(mat, window=10, ignore_diags=2, norm_by_median=True):
         If True, normalize the insulation score by its NaN-median.
 
     """
-    if (ignore_diags):
+    if ignore_diags:
         mat = mat.copy()
-        for i in range(-ignore_diags+1, ignore_diags):
+        for i in range(-ignore_diags + 1, ignore_diags):
             numutils.set_diag(mat, np.nan, i)
 
     with warnings.catch_warnings():
@@ -330,10 +341,10 @@ def _insul_diamond_dense(mat, window=10, ignore_diags=2, norm_by_median=True):
         N = mat.shape[0]
         score = np.nan * np.ones(N)
         for i in range(0, N):
-            lo = max(0, i+1-window)
-            hi = min(i+window, N)
+            lo = max(0, i + 1 - window)
+            hi = min(i + window, N)
             # nanmean of interactions to reduce the effect of bad bins
-            score[i] = np.nanmean(mat[lo:i+1, i:hi])
+            score[i] = np.nanmean(mat[lo : i + 1, i:hi])
         if norm_by_median:
             score /= np.nanmedian(score)
     return score
@@ -342,12 +353,12 @@ def _insul_diamond_dense(mat, window=10, ignore_diags=2, norm_by_median=True):
 def _find_insulating_boundaries_dense(
     clr,
     window_bp=100000,
-    balance='weight',
+    balance="weight",
     min_dist_bad_bin=2,
     ignore_diags=None,
     chromosomes=None,
 ):
-    '''Calculate the diamond insulation scores and call insulating boundaries.
+    """Calculate the diamond insulation scores and call insulating boundaries.
 
     Parameters
     ----------
@@ -368,32 +379,35 @@ def _find_insulating_boundaries_dense(
     ins_table : pandas.DataFrame
         A table containing the insulation scores of the genomic bins and
         the insulating boundary strengths.
-    '''
+    """
     if chromosomes is None:
         chromosomes = clr.chromnames
 
-    bin_size = clr.info['bin-size']
-    ignore_diags = (ignore_diags
-                    if ignore_diags is not None
-                    else clr._load_attrs(clr.root.rstrip('/')+'/bins/weight')['ignore_diags'])
+    bin_size = clr.info["bin-size"]
+    ignore_diags = (
+        ignore_diags
+        if ignore_diags is not None
+        else clr._load_attrs(clr.root.rstrip("/") + "/bins/weight")["ignore_diags"]
+    )
     window_bins = window_bp // bin_size
 
-    if (window_bp % bin_size != 0):
+    if window_bp % bin_size != 0:
         raise Exception(
-            'The window size ({}) has to be a multiple of the bin size {}'.format(
-                window_bp, bin_size))
+            "The window size ({}) has to be a multiple of the bin size {}".format(
+                window_bp, bin_size
+            )
+        )
 
     ins_chrom_tables = []
     for chrom in chromosomes:
-        ins_chrom = clr.bins().fetch(chrom)[['chrom', 'start', 'end']]
-        is_bad_bin = np.isnan(clr.bins().fetch(chrom)['weight'].values)
+        ins_chrom = clr.bins().fetch(chrom)[["chrom", "start", "end"]]
+        is_bad_bin = np.isnan(clr.bins().fetch(chrom)["weight"].values)
 
         m = clr.matrix(balance=balance).fetch(chrom)
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
-            ins_track = _insul_diamond_dense(
-                m, window_bins, ignore_diags)
+            ins_track = _insul_diamond_dense(m, window_bins, ignore_diags)
             ins_track[ins_track == 0] = np.nan
             ins_track = np.log2(ins_track)
 
@@ -402,23 +416,21 @@ def _find_insulating_boundaries_dense(
             if i == 0:
                 bad_bin_neighbor = bad_bin_neighbor | is_bad_bin
             else:
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[
-                    [True]*i, is_bad_bin[:-i]]
-                bad_bin_neighbor = bad_bin_neighbor | np.r_[
-                    is_bad_bin[i:], [True]*i]
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[[True] * i, is_bad_bin[:-i]]
+                bad_bin_neighbor = bad_bin_neighbor | np.r_[is_bad_bin[i:], [True] * i]
 
         ins_track[bad_bin_neighbor] = np.nan
-        ins_chrom['bad_bin_masked'] = bad_bin_neighbor
+        ins_chrom["bad_bin_masked"] = bad_bin_neighbor
 
         ins_track[~np.isfinite(ins_track)] = np.nan
 
-        ins_chrom['log2_insulation_score_{}'.format(window_bp)] = ins_track
+        ins_chrom["log2_insulation_score_{}".format(window_bp)] = ins_track
 
         poss, proms = peaks.find_peak_prominence(-ins_track)
         ins_prom_track = np.zeros_like(ins_track) * np.nan
         ins_prom_track[poss] = proms
-        ins_chrom['boundary_strength_{}'.format(window_bp)] = ins_prom_track
-        ins_chrom['boundary_strength_{}'.format(window_bp)] = ins_prom_track
+        ins_chrom["boundary_strength_{}".format(window_bp)] = ins_prom_track
+        ins_chrom["boundary_strength_{}".format(window_bp)] = ins_prom_track
 
         ins_chrom_tables.append(ins_chrom)
 

--- a/cooltools/insulation.py
+++ b/cooltools/insulation.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO)
 def get_n_pixels(bad_bin_mask, window=10, ignore_diags=2):
     """
     Calculate the number of "good" pixels in a diamond at each bin.
-    
+
     """
     N = len(bad_bin_mask)
     n_pixels = np.zeros(N)
@@ -141,7 +141,7 @@ def calculate_insulation_score(
         to the output table.
     verbose : bool
         If True, report real-time progress.
-        
+
     Returns
     -------
     ins_table : pandas.DataFrame
@@ -228,27 +228,27 @@ def find_boundaries(
     is_bad_bin_key="is_bad_bin",
 ):
     """Call insulating boundaries.
-    Find all local minima of the log2(insulation score) and calculate their 
+    Find all local minima of the log2(insulation score) and calculate their
     chromosome-wide topographic prominence.
-    
+
     Parameters
     ----------
     ins_table : pandas.DataFrame
         A bin table with columns containing log2(insulation score),
-        the number of valid pixels per diamond and (optionally) the mask 
+        the number of valid pixels per diamond and (optionally) the mask
         of bad bins.
     min_frac_valid_pixels : float
-        The minimal fraction of valid pixels in a diamond to be used in 
+        The minimal fraction of valid pixels in a diamond to be used in
         boundary picking and prominence calculation.
     min_dist_bad_bin : int
-        The minimal allowed distance to a bad bin. 
+        The minimal allowed distance to a bad bin.
         Ignore bins that have a bad bin closer than this distance.
     log2_ins_key, n_valid_pixels_key : str
         The names of the columns containing log2_insulation_score and
         the number of valid pixels per diamond. When a template
-        containing `{WINDOW}` is provided, the calculation is repeated 
+        containing `{WINDOW}` is provided, the calculation is repeated
         for all pairs of columns matching the template.
-        
+
     Returns
     -------
     ins_table : pandas.DataFrame
@@ -266,7 +266,7 @@ def find_boundaries(
     if "{WINDOW}" in log2_ins_key:
         windows = set()
         for col in ins_table.columns:
-            m = re.match(log2_ins_key.format(WINDOW="(\d+)"), col)
+            m = re.match(log2_ins_key.format(WINDOW=r"(\d+)"), col)
             if m:
                 windows.add(int(m.groups()[0]))
     else:

--- a/cooltools/io/__init__.py
+++ b/cooltools/io/__init__.py
@@ -1,3 +1,2 @@
 from .fastsavetxt import array2txt
 from .cool2cworld import dump_cworld, dump_cworld_tar
-

--- a/cooltools/io/cool2cworld.py
+++ b/cooltools/io/cool2cworld.py
@@ -8,6 +8,7 @@ from . import fastsavetxt
 
 import cooler
 
+
 def dump_cworld(
     in_cooler,
     out=None,
@@ -15,8 +16,8 @@ def dump_cworld(
     iced=False,
     iced_unity=False,
     buffer_size=int(1e8),
-    ):
-    '''
+):
+    """
     Dump a genome-wide contact matrix from cooler into a CWorld-format
     text matrix.
 
@@ -44,21 +45,21 @@ def dump_cworld(
 
     buffer_size : int
         The chunk size for iterating over the rows of the Hi-C matrix.
-    '''
+    """
 
     # Prepare the out pipe and the clean-up function.
-    if not(out):
-        out = io.BytesIO(b'')
+    if not (out):
+        out = io.BytesIO(b"")
     if issubclass(type(out), str) or issubclass(type(out), bytearray):
-        if out.endswith('.gz'):
+        if out.endswith(".gz"):
             writer = fastsavetxt.gzipWriter(out)
             out_pipe = writer.stdin
             close_out_func = writer.communicate
         else:
-            writer = open(out, 'wb')
+            writer = open(out, "wb")
             out_pipe = writer
             close_out_func = writer.flush
-    elif hasattr(out, 'write'):
+    elif hasattr(out, "write"):
         out_pipe = out
         close_out_func = fastsavetxt.empty_func
 
@@ -68,45 +69,46 @@ def dump_cworld(
     else:
         c = in_cooler
 
-    res = c.info['bin-size']
-    gname = c.info['genome-assembly']
+    res = c.info["bin-size"]
+    gname = c.info["genome-assembly"]
 
-    bins = c.bins()[:] if not(region) else c.bins().fetch(region)
+    bins = c.bins()[:] if not (region) else c.bins().fetch(region)
     nbins = len(bins)
 
-    col_headers = '\t'.join(
-        ['{}x{}'.format(nbins, nbins)] +
-        ['{}|{}|{}:{}-{}'.format(
-            binidx, gname, b.chrom, b.start+1, b.end)
-         for binidx, b in bins.iterrows()
+    col_headers = "\t".join(
+        ["{}x{}".format(nbins, nbins)]
+        + [
+            "{}|{}|{}:{}-{}".format(binidx, gname, b.chrom, b.start + 1, b.end)
+            for binidx, b in bins.iterrows()
         ]
     ).encode()
 
     row_headers = [
-        '{}|{}|{}:{}-{}'.format(
-            binidx1, gname, b1.chrom, b1.start+1, b1.end).encode()
+        "{}|{}|{}:{}-{}".format(binidx1, gname, b1.chrom, b1.start + 1, b1.end).encode()
         for binidx1, b1 in bins.iterrows()
     ]
 
     # Iterate over a matrix one block at a time.
     nrows_per_step = max(1, buffer_size // nbins)
     for i in range(nbins // nrows_per_step + 1):
-        lo = min(nbins, i*nrows_per_step)
-        hi = min(nbins, (i+1)*nrows_per_step)
+        lo = min(nbins, i * nrows_per_step)
+        hi = min(nbins, (i + 1) * nrows_per_step)
         if hi <= lo:
             break
-        mat = (c.matrix(balance=iced)
-               if not(region) else
-               c.matrix(balance=iced).fetch(region))[lo:hi]
+        mat = (
+            c.matrix(balance=iced)
+            if not (region)
+            else c.matrix(balance=iced).fetch(region)
+        )[lo:hi]
         if iced and (not iced_unity):
-            mat *= (c._load_attrs('/bins/weight')['scale'])
+            mat *= c._load_attrs("/bins/weight")["scale"]
 
         fastsavetxt.array2txt(
             mat,
             out_pipe,
-            format_string = b'%.8f' if iced_unity else b'%.4lf',
-            header=col_headers if i==0 else None,
-            row_headers = row_headers[lo:hi],
+            format_string=b"%.8f" if iced_unity else b"%.4lf",
+            header=col_headers if i == 0 else None,
+            row_headers=row_headers[lo:hi],
         )
 
     if issubclass(type(out), io.BytesIO):
@@ -116,10 +118,9 @@ def dump_cworld(
 
 
 def dump_cworld_tar(
-    cooler_paths,
-    out_path,
-    ):
-    '''
+    cooler_paths, out_path,
+):
+    """
     Makes a CWorld .tar archive with binned contact maps at multiple resolutions
     in .matrix.txt.gz format.
 
@@ -132,32 +133,26 @@ def dump_cworld_tar(
     out_path : str
         The path to the output file.
 
-    '''
+    """
 
     dataset_name = os.path.splitext(os.path.split(out_path)[1])[0]
 
     with tempfile.TemporaryDirectory() as cworld_tmp_path:
         for cooler_path in cooler_paths:
-            res = cooler.Cooler(cooler_path).info['bin-size']
-            os.mkdir(os.path.join(cworld_tmp_path, 'C-'+str(res)))
-            for iced, iced_label in [(True,'iced'), (False, 'raw')]:
-                folder_path = os.path.join(cworld_tmp_path, 'C-'+str(res), iced_label)
+            res = cooler.Cooler(cooler_path).info["bin-size"]
+            os.mkdir(os.path.join(cworld_tmp_path, "C-" + str(res)))
+            for iced, iced_label in [(True, "iced"), (False, "raw")]:
+                folder_path = os.path.join(cworld_tmp_path, "C-" + str(res), iced_label)
                 os.mkdir(folder_path)
 
                 mat_path = os.path.join(
                     folder_path,
-                    '{}__C-{}-{}.matrix.gz'.format(dataset_name, res, iced_label))
+                    "{}__C-{}-{}.matrix.gz".format(dataset_name, res, iced_label),
+                )
 
                 dump_cworld(
-                    in_cooler=cooler_path,
-                    out=mat_path,
-                    iced=iced,
-                    iced_unity=False
-                    )
+                    in_cooler=cooler_path, out=mat_path, iced=iced, iced_unity=False
+                )
 
-        with tarfile.open(out_path, mode='w') as archive:
-            archive.add(
-                cworld_tmp_path,
-                arcname=dataset_name,
-                recursive=True)
-
+        with tarfile.open(out_path, mode="w") as archive:
+            archive.add(cworld_tmp_path, arcname=dataset_name, recursive=True)

--- a/cooltools/lib/_query.py
+++ b/cooltools/lib/_query.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 import numpy as np
 import pandas as pd
-#from scipy.sparse import coo_matrix
+
+# from scipy.sparse import coo_matrix
 from cooler.core import _IndexingMixin
 
 
@@ -28,15 +29,16 @@ class CSRSelector(_IndexingMixin):
     >>> query = selector[lo1:hi1, lo2:hi2]
 
     """
+
     def __init__(self, grp, shape, field, chunksize):
         self.grp = grp
         self.shape = shape
         self.field = field
         self.chunksize = chunksize
-        self.offset_selector = grp['indexes']['bin1_offset']
-        self.bin1_selector = grp['pixels']['bin1_id']
-        self.bin2_selector = grp['pixels']['bin2_id']
-        self.data_selector = grp['pixels'][field]
+        self.offset_selector = grp["indexes"]["bin1_offset"]
+        self.bin1_selector = grp["pixels"]["bin1_id"]
+        self.bin2_selector = grp["pixels"]["bin2_id"]
+        self.data_selector = grp["pixels"][field]
 
     def _make_getchunk(self, ispan, jspan):
         # Factory for function that executes any piece of a 2D range query by
@@ -54,26 +56,22 @@ class CSRSelector(_IndexingMixin):
             offsets = []
             loc_pruned_offsets = []
         else:
-            offsets = self.offset_selector[i0:i1 + 1]
+            offsets = self.offset_selector[i0 : i1 + 1]
             loc_pruned_offsets = arg_prune_partition(offsets, self.chunksize)
 
         self._loc_pruned_offsets = loc_pruned_offsets
-        #i0 -- matrix row number offset
-        #o0 -- corresponding pixel id offset = offsets[0]
+        # i0 -- matrix row number offset
+        # o0 -- corresponding pixel id offset = offsets[0]
 
         # let's take the downsampled subset of pixel id offsets [o0, ...., o1]
         # each successive pair corresponds to a "piece" of the query
         def getchunk(chunk_id, include_index=False):
-            out = {
-                'bin1_id': [],
-                'bin2_id': [],
-                field: []
-            }
+            out = {"bin1_id": [], "bin2_id": [], field: []}
             if include_index:
-                out['__index'] = []
+                out["__index"] = []
 
             # extract a chunk of on-disk rows
-            oi, of = loc_pruned_offsets[chunk_id], loc_pruned_offsets[chunk_id+1]
+            oi, of = loc_pruned_offsets[chunk_id], loc_pruned_offsets[chunk_id + 1]
             p0, p1 = offsets[oi], offsets[of]
             slc = slice(p0, p1)
 
@@ -101,21 +99,21 @@ class CSRSelector(_IndexingMixin):
                 # shortcut for row data
                 rows = np.full(len(cols), i0 + i, dtype=bin1_selector.dtype)
 
-                out['bin1_id'].append(rows)
-                out['bin2_id'].append(cols)
+                out["bin1_id"].append(rows)
+                out["bin2_id"].append(cols)
                 out[field].append(data)
                 if include_index:
-                    out['__index'].append(ind_extracted[lo:hi][mask])
+                    out["__index"].append(ind_extracted[lo:hi][mask])
 
             if len(out):
                 for k in out.keys():
                     out[k] = np.concatenate(out[k], axis=0)
             else:
-                out['bin1_id'] = np.array([], dtype=bin1_selector.dtype)
-                out['bin2_id'] = np.array([], dtype=bin2_selector.dtype)
-                out[field]     = np.array([], dtype=data_selector.dtype)
+                out["bin1_id"] = np.array([], dtype=bin1_selector.dtype)
+                out["bin2_id"] = np.array([], dtype=bin2_selector.dtype)
+                out[field] = np.array([], dtype=data_selector.dtype)
                 if include_index:
-                    out['__index'] = np.array([], dtype=np.int64)
+                    out["__index"] = np.array([], dtype=np.int64)
 
             return out
 
@@ -126,8 +124,7 @@ class CSRSelector(_IndexingMixin):
         ispan = self._process_slice(s1, self.shape[0])
         jspan = self._process_slice(s2, self.shape[1])
         getchunk, loc_pruned_offsets = self._make_getchunk(ispan, jspan)
-        return RangeQuery(self, ispan, jspan, self.field, getchunk,
-                          loc_pruned_offsets)
+        return RangeQuery(self, ispan, jspan, self.field, getchunk, loc_pruned_offsets)
 
 
 class RangeQuery(object):
@@ -135,6 +132,7 @@ class RangeQuery(object):
     Executor that fulfills a partitioned 2D range query using a variety of outputs.
 
     """
+
     def __init__(self, selector, ispan, jspan, field, getchunk, loc_pruned_offsets):
         self.selector = selector
         self.ispan = ispan
@@ -160,11 +158,12 @@ class RangeQuery(object):
         result = list(self.read_chunked(include_index))
         return {
             k: np.concatenate([d[k] for d in result], axis=0)
-               for k in ['bin1_id', 'bin2_id', self.field]
+            for k in ["bin1_id", "bin2_id", self.field]
         }
 
     def __repr__(self):
-        return ('{self.__class__.__name__}'
-                '({self.ispan}, {self.jspan}, "{self.field}", ...) '
-                '[{n} piece(s)]').format(
-                   self=self, n=self.n_chunks)
+        return (
+            "{self.__class__.__name__}"
+            '({self.ispan}, {self.jspan}, "{self.field}", ...) '
+            "[{n} piece(s)]"
+        ).format(self=self, n=self.n_chunks)

--- a/cooltools/lib/common.py
+++ b/cooltools/lib/common.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 
-def assign_supports(features, supports, labels=False, suffix=''):
+def assign_supports(features, supports, labels=False, suffix=""):
     """
     Assign support regions to a table of genomic intervals.
 
@@ -18,33 +18,34 @@ def assign_supports(features, supports, labels=False, suffix=''):
     features = features.copy()
     supp_col = pd.Series(index=features.index, data=np.nan)
 
-    c = 'chrom' + suffix
-    s = 'start' + suffix
-    e = 'end' + suffix
+    c = "chrom" + suffix
+    s = "start" + suffix
+    e = "end" + suffix
     for col in (c, s, e):
         if col not in features.columns:
             raise ValueError(
-                'Column "{}" not found in features data frame.'.format(col))
+                'Column "{}" not found in features data frame.'.format(col)
+            )
 
     for i, region in enumerate(supports):
         # single-region support
         if len(region) == 3:
             sel = (features[c] == region[0]) & (features[e] >= region[1])
             if region[2] is not None:
-                sel &= (features[s] < region[2])
+                sel &= features[s] < region[2]
         # paired-region support
         elif len(region) == 2:
             region1, region2 = region
             sel1 = (features[c] == region1[0]) & (features[e] >= region1[1])
             if region1[2] is not None:
-                sel1 &= (features[s] < region1[2])
+                sel1 &= features[s] < region1[2]
             sel2 = (features[c] == region2[0]) & (features[e] >= region2[1])
             if region2[2] is not None:
-                sel2 &= (features[s] < region2[2])
+                sel2 &= features[s] < region2[2]
             sel = sel1 | sel2
         supp_col.loc[sel] = i
 
     if labels:
-        supp_col = supp_col.map(lambda i: supports[int(i)], na_action='ignore')
+        supp_col = supp_col.map(lambda i: supports[int(i)], na_action="ignore")
 
     return supp_col

--- a/cooltools/lib/numutils.py
+++ b/cooltools/lib/numutils.py
@@ -18,12 +18,15 @@ from ._numutils import (
 
 
 def get_diag(arr, i=0):
-    '''Get the i-th diagonal of a matrix.
+    """Get the i-th diagonal of a matrix.
     This solution was borrowed from
     http://stackoverflow.com/questions/9958577/changing-the-values-of-the-diagonal-of-a-matrix-in-numpy
-    '''
+    """
     return arr.ravel()[
-        max(i, -arr.shape[1]*i):max(0, (arr.shape[1]-i))*arr.shape[1]:arr.shape[1]+1]
+        max(i, -arr.shape[1] * i) : max(0, (arr.shape[1] - i))
+        * arr.shape[1] : arr.shape[1]
+        + 1
+    ]
 
 
 def set_diag(arr, x, i=0, copy=False):
@@ -66,12 +69,12 @@ def set_diag(arr, x, i=0, copy=False):
 
 
 def fill_diag(arr, x, i=0, copy=True):
-    '''Identical to set_diag, but returns a copy by default'''
+    """Identical to set_diag, but returns a copy by default"""
     return set_diag(arr, x, i, copy)
 
 
 def fill_na(arr, value=0, copy=True):
-    '''Replaces np.nan entries in an array with the provided value.
+    """Replaces np.nan entries in an array with the provided value.
 
     Parameters
     ----------
@@ -84,15 +87,15 @@ def fill_na(arr, value=0, copy=True):
         If True, creates a copy of x, otherwise replaces values in-place.
         By default, True.
 
-    '''
+    """
     if copy:
         arr = arr.copy()
     arr[np.isnan(arr)] = value
     return arr
 
 
-def dist_to_mask(mask, side='min'):
-    '''
+def dist_to_mask(mask, side="min"):
+    """
     Calculate the distance to the nearest True element of an array.
 
     Parameters
@@ -115,35 +118,39 @@ def dist_to_mask(mask, side='min'):
     ------
     The solution is borrowed from https://stackoverflow.com/questions/18196811/cumsum-reset-at-nan
 
-    '''
-    if side not in ['left', 'right', 'min', 'max']:
-        raise ValueError('side can be `left`, `right`, `min` or `max`')
-    if side == 'min':
-        return np.minimum(dist_to_mask(mask, side='left'), dist_to_mask(mask, side='right'))
-    if side == 'max':
-        return np.maximum(dist_to_mask(mask, side='left'), dist_to_mask(mask, side='right'))
+    """
+    if side not in ["left", "right", "min", "max"]:
+        raise ValueError("side can be `left`, `right`, `min` or `max`")
+    if side == "min":
+        return np.minimum(
+            dist_to_mask(mask, side="left"), dist_to_mask(mask, side="right")
+        )
+    if side == "max":
+        return np.maximum(
+            dist_to_mask(mask, side="left"), dist_to_mask(mask, side="right")
+        )
 
     mask = np.asarray(mask)
-    if side == 'right':
+    if side == "right":
         mask = mask[::-1]
 
-    d = np.diff(np.r_[0., np.cumsum(~mask)[mask]])
+    d = np.diff(np.r_[0.0, np.cumsum(~mask)[mask]])
     v = mask.astype(int).copy()
     v[mask] = d
     dist = (~mask).cumsum() - np.cumsum(v)
 
-    return dist[::-1] if side == 'right' else dist
+    return dist[::-1] if side == "right" else dist
 
 
 def get_finite(arr):
-    '''
+    """
     Select only finite elements of an array.
-    '''
+    """
     return arr[np.isfinite(arr)]
 
 
 def fill_inf(arr, pos_value=0, neg_value=0, copy=True):
-    '''Replaces positive and negative infinity entries in an array
+    """Replaces positive and negative infinity entries in an array
        with the provided values.
 
     Parameters
@@ -161,7 +168,7 @@ def fill_inf(arr, pos_value=0, neg_value=0, copy=True):
         If True, creates a copy of x, otherwise replaces values in-place.
         By default, True.
 
-    '''
+    """
     if copy:
         arr = arr.copy()
     arr[np.isposinf(arr)] = pos_value
@@ -170,7 +177,7 @@ def fill_inf(arr, pos_value=0, neg_value=0, copy=True):
 
 
 def fill_nainf(arr, value=0, copy=True):
-    '''Replaces np.nan and np.inf entries in an array with the provided value.
+    """Replaces np.nan and np.inf entries in an array with the provided value.
 
     Parameters
     ----------
@@ -185,15 +192,15 @@ def fill_nainf(arr, value=0, copy=True):
 
     .. note:: differs from np.nan_to_num in that it replaces np.inf with the same
     number as np.nan.
-    '''
+    """
     if copy:
         arr = arr.copy()
     arr[~np.isfinite(arr)] = value
     return arr
 
 
-def interp_nan(a_init, pad_zeros=True, method='linear', verbose=False):
-    '''Linearly interpolate to fill NaN rows and columns in a matrix.
+def interp_nan(a_init, pad_zeros=True, method="linear", verbose=False):
+    """Linearly interpolate to fill NaN rows and columns in a matrix.
     Also interpolates NaNs in 1D arrays.
 
     Parameters
@@ -218,7 +225,7 @@ def interp_nan(a_init, pad_zeros=True, method='linear', verbose=False):
     2D case assumes that entire rows or columns are masked & edges to be
     NaN-free, but is much faster than griddata implementation.
 
-    '''
+    """
     shape = np.shape(a_init)
     if pad_zeros:
         a = np.zeros(tuple(s + 2 for s in shape))
@@ -231,15 +238,14 @@ def interp_nan(a_init, pad_zeros=True, method='linear', verbose=False):
     isnan = np.isnan(a)
     if np.sum(isnan) == 0:
         if verbose:
-            print('no nans to interpolate')
+            print("no nans to interpolate")
         return a_init
 
     if a.ndim == 2:
         if verbose:
-            print('interpolating 2D matrix')
-        if (np.any(isnan[:, 0] | isnan[:, -1]) or
-                np.any(isnan[0, :] | isnan[-1, :])):
-            raise ValueError('Edges must not have NaNs')
+            print("interpolating 2D matrix")
+        if np.any(isnan[:, 0] | isnan[:, -1]) or np.any(isnan[0, :] | isnan[-1, :]):
+            raise ValueError("Edges must not have NaNs")
         # Rows/cols to be considered fully null may have non-NaN diagonals
         # so we'll take the maximum NaN count to identify them
         n_nans_by_row = np.sum(isnan, axis=1)
@@ -247,22 +253,21 @@ def interp_nan(a_init, pad_zeros=True, method='linear', verbose=False):
         i_inds = np.where(n_nans_by_row < np.max(n_nans_by_row))[0]
         j_inds = np.where(n_nans_by_col < np.max(n_nans_by_col))[0]
         if np.sum(isnan[np.ix_(i_inds, j_inds)]) > 0:
-            raise AssertionError('Found additional NaNs')
+            raise AssertionError("Found additional NaNs")
         interpolator = partial(
             scipy.interpolate.interpn,
             (i_inds, j_inds),
             a[np.ix_(i_inds, j_inds)],
             method=method,
-            bounds_error=False)
+            bounds_error=False,
+        )
     else:
         if verbose:
-            print('interpolating 1D vector')
+            print("interpolating 1D vector")
         inds = np.arange(len(a))
         interpolator = scipy.interpolate.interp1d(
-            inds[~isnan],
-            a[~isnan],
-            kind=method,
-            bounds_error=False)
+            inds[~isnan], a[~isnan], kind=method, bounds_error=False
+        )
 
     loc = np.where(isnan)
     a[loc] = interpolator(loc)
@@ -274,14 +279,14 @@ def interp_nan(a_init, pad_zeros=True, method='linear', verbose=False):
 
 
 def slice_sorted(arr, lo, hi):
-    '''Get the subset of a sorted array with values >=lo and <hi.
+    """Get the subset of a sorted array with values >=lo and <hi.
     A faster version of arr[(arr>=lo) & (arr<hi)]
-    '''
-    return arr[np.searchsorted(arr, lo):np.searchsorted(arr, hi)]
+    """
+    return arr[np.searchsorted(arr, lo) : np.searchsorted(arr, hi)]
 
 
 def MAD(arr, axis=None, has_nans=False):
-    '''Calculate the Median Absolute Deviation from the median.
+    """Calculate the Median Absolute Deviation from the median.
 
     Parameters
     ----------
@@ -294,7 +299,7 @@ def MAD(arr, axis=None, has_nans=False):
 
     has_nans : bool
         If True, use the slower NaN-aware method to calculate medians.
-    '''
+    """
 
     if has_nans:
         return np.nanmedian(np.abs(arr - np.nanmedian(arr, axis)), axis)
@@ -303,7 +308,7 @@ def MAD(arr, axis=None, has_nans=False):
 
 
 def COMED(xs, ys, has_nans=False):
-    '''Calculate the comedian - the robust median-based counterpart of
+    """Calculate the comedian - the robust median-based counterpart of
     Pearson's r.
 
     comedian = med((xs-median(xs))*(ys-median(ys))) / MAD(xs) / MAD(ys)
@@ -317,7 +322,7 @@ def COMED(xs, ys, has_nans=False):
     .. note:: Citations: "On MAD and comedians" by Michael Falk (1997),
     "Robust Estimation of the Correlation Coefficient: An Attempt of Survey"
     by Georgy Shevlyakov and Pavel Smirnov (2011)
-    '''
+    """
 
     if has_nans:
         mask = np.isfinite(xs) & np.isfinite(ys)
@@ -326,13 +331,13 @@ def COMED(xs, ys, has_nans=False):
 
     med_x = np.median(xs)
     med_y = np.median(ys)
-    comedian = np.median((xs-med_x) * (ys-med_y)) / MAD(xs) / MAD(ys)
+    comedian = np.median((xs - med_x) * (ys - med_y)) / MAD(xs) / MAD(ys)
 
     return comedian
 
 
-def normalize_score(arr, norm='z', axis=None, has_nans=True):
-    '''Normalize an array by subtracting the first moment and
+def normalize_score(arr, norm="z", axis=None, has_nans=True):
+    """Normalize an array by subtracting the first moment and
     dividing the residual by the second.
 
     Parameters
@@ -361,12 +366,12 @@ def normalize_score(arr, norm='z', axis=None, has_nans=True):
         If True, use slower NaN-aware methods to calculate the
         normalization parameters.
 
-    '''
+    """
 
     norm_arr = np.copy(arr)
     norm = norm.lower()
 
-    if norm == 'z':
+    if norm == "z":
         if has_nans:
             norm_arr -= np.nanmean(norm_arr, axis=axis)
             norm_arr /= np.nanstd(norm_arr, axis=axis)
@@ -374,22 +379,22 @@ def normalize_score(arr, norm='z', axis=None, has_nans=True):
             norm_arr -= np.mean(norm_arr, axis=axis)
             norm_arr /= np.std(norm_arr, axis=axis)
 
-    elif norm == 'mad' or norm == 'madz':
+    elif norm == "mad" or norm == "madz":
         if has_nans:
             norm_arr -= np.nanmedian(norm_arr, axis=axis)
         else:
             norm_arr -= np.median(norm_arr, axis=axis)
         norm_arr /= MAD(norm_arr, axis=axis, has_nans=has_nans)
-        if norm == 'madz':
+        if norm == "madz":
             norm_arr *= 0.67449
     else:
-        raise ValueError('Unknown norm type: {}'.format(norm))
+        raise ValueError("Unknown norm type: {}".format(norm))
 
     return norm_arr
 
 
 def stochastic_sd(arr, n=10000, seed=0):
-    '''Estimate the standard deviation of an array by considering only the
+    """Estimate the standard deviation of an array by considering only the
     subset of its elements.
 
     Parameters
@@ -400,13 +405,14 @@ def stochastic_sd(arr, n=10000, seed=0):
 
     seed : int
         The seed for the random number generator.
-    '''
+    """
     arr = np.asarray(arr)
     if arr.size < n:
         return np.sqrt(arr.var())
     else:
         return np.sqrt(
-            np.random.RandomState(seed).choice(arr.flat, n, replace=True).var())
+            np.random.RandomState(seed).choice(arr.flat, n, replace=True).var()
+        )
 
 
 def is_symmetric(mat):
@@ -452,17 +458,19 @@ def get_eig(mat, n=3, mask_zero_rows=False, subtract_mean=False, divide_by_mean=
 
     """
     symmetric = is_symmetric(mat)
-    if (symmetric
+    if (
+        symmetric
         and np.sum(np.sum(np.abs(mat), axis=0) == 0) > 0
         and not mask_zero_rows
-        ):
+    ):
         warnings.warn(
             "The matrix contains empty rows/columns and is symmetric. "
-            "Mask the empty rows with remove_zeros=True")
+            "Mask the empty rows with remove_zeros=True"
+        )
 
     if mask_zero_rows:
         if not is_symmetric(mat):
-            raise ValueError('The input matrix must be symmetric!')
+            raise ValueError("The input matrix must be symmetric!")
 
         mask = np.sum(np.abs(mat), axis=0) != 0
         mat_collapsed = mat[mask, :][:, mask]
@@ -471,7 +479,8 @@ def get_eig(mat, n=3, mask_zero_rows=False, subtract_mean=False, divide_by_mean=
             n=n,
             mask_zero_rows=False,
             subtract_mean=subtract_mean,
-            divide_by_mean=divide_by_mean)
+            divide_by_mean=divide_by_mean,
+        )
         n_rows = mat.shape[0]
         eigvecs = np.full((n, n_rows), np.nan)
         for i in range(n):
@@ -520,7 +529,7 @@ def _logbins_numba(lo, hi, ratio=0, N=0, prepend_zero=False):
         N = np.log(hi / lo) / np.log(ratio)
     elif N == 0:
         raise ValueError("Please specify N or ratio")
-    data10 = 10**np.linspace(np.log10(lo), np.log10(hi), int(N))
+    data10 = 10 ** np.linspace(np.log10(lo), np.log10(hi), int(N))
     data10 = np.rint(data10)
     data10_int = np.sort(np.unique(data10)).astype(np.int_)
     assert data10_int[0] == lo
@@ -532,10 +541,9 @@ def _logbins_numba(lo, hi, ratio=0, N=0, prepend_zero=False):
 
 @numba.njit
 def observed_over_expected(
-        matrix,
-        mask=np.empty(shape=(0), dtype=np.bool_),
-        dist_bin_edge_ratio=1.03):
-    '''
+    matrix, mask=np.empty(shape=(0), dtype=np.bool_), dist_bin_edge_ratio=1.03
+):
+    """
     Normalize the contact matrix for distance-dependent contact decay.
     The diagonals of the matrix, corresponding to contacts between loci pairs
     with a fixed distance, are grouped into exponentially growing bins of
@@ -561,7 +569,7 @@ def observed_over_expected(
         The sum of contact frequencies in each distance bin.
     n_pixels : np.ndarray
         The total number of valid pixels in each distance bin.
-    '''
+    """
 
     N = matrix.shape[0]
 
@@ -572,10 +580,9 @@ def observed_over_expected(
     elif mask.ndim == 2:
         # Numba expects mask to be a 1d array, so we need to hint
         # that it is now a 2d array
-        mask2d = mask.reshape(
-            (int(np.sqrt(mask.size)), int(np.sqrt(mask.size))))
+        mask2d = mask.reshape((int(np.sqrt(mask.size)), int(np.sqrt(mask.size))))
     else:
-        raise ValueError('The mask must be either 1D or 2D.')
+        raise ValueError("The mask must be either 1D or 2D.")
 
     data = np.copy(matrix).astype(np.float64)
 
@@ -587,15 +594,15 @@ def observed_over_expected(
 
     bin_idx, n_pixels, sum_pixels = 0, 0, 0
 
-    for bin_idx, lo, hi in zip(range(len(dist_bins)-1),
-                               dist_bins[:-1],
-                               dist_bins[1:]):
+    for bin_idx, lo, hi in zip(
+        range(len(dist_bins) - 1), dist_bins[:-1], dist_bins[1:]
+    ):
         sum_pixels = 0
         n_pixels = 0
         for offset in range(lo, hi):
-            for j in range(0, N-offset):
-                if not has_mask or mask2d[offset+j, j]:
-                    sum_pixels += data[offset+j, j]
+            for j in range(0, N - offset):
+                if not has_mask or mask2d[offset + j, j]:
+                    sum_pixels += data[offset + j, j]
                     n_pixels += 1
 
         n_pixels_arr[bin_idx] = n_pixels
@@ -608,19 +615,20 @@ def observed_over_expected(
             continue
 
         for offset in range(lo, hi):
-            for j in range(0, N-offset):
-                if not has_mask or mask2d[offset+j, j]:
+            for j in range(0, N - offset):
+                if not has_mask or mask2d[offset + j, j]:
 
                     data[offset + j, j] /= mean_pixel
                     if offset > 0:
-                        data[j, offset+j] /= mean_pixel
+                        data[j, offset + j] /= mean_pixel
 
     return data, dist_bins, sum_pixels_arr, n_pixels_arr
 
 
 @numba.jit  # (nopython=True)
 def iterative_correction_symmetric(
-        x, max_iter=1000, ignore_diags=0, tol=1e-5, verbose=False):
+    x, max_iter=1000, ignore_diags=0, tol=1e-5, verbose=False
+):
     """The main method for correcting DS and SS read data.
     By default does iterative correction, but can perform an M-time correction
 
@@ -643,9 +651,9 @@ def iterative_correction_symmetric(
     if ignore_diags > 0:
         for d in range(0, ignore_diags):
             #            set_diag(_x, 0, d) # explicit cycles are easier to jit
-            for j in range(0, N-d):
-                _x[j, j+d] = 0
-                _x[j+d, j] = 0
+            for j in range(0, N - d):
+                _x[j, j + d] = 0
+                _x[j + d, j] = 0
     totalBias = np.ones(N, np.double)
 
     converged = False
@@ -655,7 +663,7 @@ def iterative_correction_symmetric(
     for iternum in range(max_iter):
         s = np.sum(_x, axis=1)
 
-        mask = (s == 0)
+        mask = s == 0
 
         s = s / np.mean(s[~mask])
         s[mask] = 1
@@ -664,7 +672,7 @@ def iterative_correction_symmetric(
         s += 1
         totalBias *= s
 
-        #_x = _x / s[:, None]  / s[None,:]
+        # _x = _x / s[:, None]  / s[None,:]
         # an explicit cycle is 2x faster here
         for i in range(N):
             for j in range(N):
@@ -681,14 +689,13 @@ def iterative_correction_symmetric(
     corr = totalBias[~mask].mean()  # mean correction factor
     _x = _x * corr * corr  # renormalizing everything
     totalBias /= corr
-    report = {'converged': converged, 'iternum': iternum}
+    report = {"converged": converged, "iternum": iternum}
 
     return _x, totalBias, report
 
 
 @numba.jit  # (nopython=True)
-def iterative_correction_asymmetric(
-        x, max_iter=1000,  tol=1e-5, verbose=False):
+def iterative_correction_asymmetric(x, max_iter=1000, tol=1e-5, verbose=False):
     """ adapted from iterative_correction_symmetric
 
     Parameters
@@ -712,24 +719,24 @@ def iterative_correction_asymmetric(
 
     for iternum in range(max_iter):
         s = np.sum(_x, axis=0)
-        mask = (s == 0)
+        mask = s == 0
         s = s / np.mean(s[~mask])
-        s[mask] = 1.
-        s -= 1.
+        s[mask] = 1.0
+        s -= 1.0
         s *= 0.8
-        s += 1.
+        s += 1.0
         totalBias *= s
 
         s2 = np.sum(_x, axis=1)
-        mask2 = (s2 == 0)
+        mask2 = s2 == 0
         s2 = s2 / np.mean(s2[~mask2])
-        s2[mask2] = 1.
-        s2 -= 1.
+        s2[mask2] = 1.0
+        s2 -= 1.0
         s2 *= 0.8
-        s2 += 1.
+        s2 += 1.0
         totalBias2 *= s2
 
-        #_x = _x / s[:, None]  / s[None,:]
+        # _x = _x / s[:, None]  / s[None,:]
         # an explicit cycle is 2x faster here
         for i in range(N2):
             for j in range(N):
@@ -749,7 +756,7 @@ def iterative_correction_asymmetric(
     _x = _x * corr * corr2  # renormalizing everything
     totalBias /= corr
     totalBias2 /= corr2
-    report = {'converged': converged, 'iternum': iternum}
+    report = {"converged": converged, "iternum": iternum}
 
     return _x, totalBias, totalBias2, report
 
@@ -766,7 +773,7 @@ class LazyToeplitz(cooler.core._IndexingMixin):
         if r is None:
             r = c
         elif c[0] != r[0]:
-            raise ValueError('First element of `c` and `r` should match')
+            raise ValueError("First element of `c` and `r` should match")
         self._c = c
         self._r = r
 
@@ -782,8 +789,8 @@ class LazyToeplitz(cooler.core._IndexingMixin):
 
         # symmetric query
         if (i0 == j0) and (i1 == j1):
-            c = C[0:(i1-i0)]
-            r = R[0:(j1-j0)]
+            c = C[0 : (i1 - i0)]
+            r = R[0 : (j1 - j0)]
 
         # asymmetric query
         else:
@@ -796,11 +803,8 @@ class LazyToeplitz(cooler.core._IndexingMixin):
                 C, R = R, C
                 transpose = True
 
-            c = np.r_[
-                R[(j0-i0): max(0, j0-i1): -1],
-                C[0: max(0, i1-j0)]
-            ]
-            r = R[(j0-i0):(j1-i0)]
+            c = np.r_[R[(j0 - i0) : max(0, j0 - i1) : -1], C[0 : max(0, i1 - j0)]]
+            r = R[(j0 - i0) : (j1 - i0)]
 
             if transpose:
                 c, r = r, c
@@ -829,64 +833,58 @@ def get_kernel(w, p, ktype):
         kernel type.
 
     """
-    width = 2*w+1
+    width = 2 * w + 1
     kernel = np.ones((width, width), dtype=np.int)
     # mesh grid:
-    y, x = np.ogrid[-w:w+1, -w:w+1]
+    y, x = np.ogrid[-w : w + 1, -w : w + 1]
 
-    if ktype == 'donut':
+    if ktype == "donut":
         # mask inner pXp square:
-        mask = ((((-p) <= x) & (x <= p)) &
-                (((-p) <= y) & (y <= p)))
+        mask = (((-p) <= x) & (x <= p)) & (((-p) <= y) & (y <= p))
         # mask vertical and horizontal
         # lines of width 1 pixel:
         mask += (x == 0) | (y == 0)
         # they are all 0:
         kernel[mask] = 0
-    elif ktype == 'vertical':
+    elif ktype == "vertical":
         # mask outside of vertical line
         # of width 3:
-        mask = (((-1 > x) | (x > 1)) & ((y >= -w)))
+        mask = ((-1 > x) | (x > 1)) & ((y >= -w))
         # mask inner pXp square:
-        mask += (((-p <= x) & (x <= p)) &
-                 ((-p <= y) & (y <= p)))
+        mask += ((-p <= x) & (x <= p)) & ((-p <= y) & (y <= p))
         # kernel masked:
         kernel[mask] = 0
-    elif ktype == 'horizontal':
+    elif ktype == "horizontal":
         # mask outside of horizontal line
         # of width 3:
-        mask = (((-1 > y) | (y > 1)) & ((x >= -w)))
+        mask = ((-1 > y) | (y > 1)) & ((x >= -w))
         # mask inner pXp square:
-        mask += (((-p <= x) & (x <= p)) &
-                 ((-p <= y) & (y <= p)))
+        mask += ((-p <= x) & (x <= p)) & ((-p <= y) & (y <= p))
         # kernel masked:
         kernel[mask] = 0
     # ACHTUNG!!! UPRIGHT AND LOWLEFT ARE SWITCHED ...
     # IT SEEMS FOR UNKNOWN REASON THAT IT SHOULD
     # BE THAT WAY ...
     # OR IT'S A MISTAKE IN hIccups AS WELL ...
-    elif ktype == 'upright':
+    elif ktype == "upright":
         # mask inner pXp square:
-        mask = (((x >= -p)) &
-                ((y <= p)))
-        mask += (x >= 0)
-        mask += (y <= 0)
+        mask = ((x >= -p)) & ((y <= p))
+        mask += x >= 0
+        mask += y <= 0
         # kernel masked:
         kernel[mask] = 0
-    elif ktype == 'lowleft':
+    elif ktype == "lowleft":
         # mask inner pXp square:
-        mask = (((x >= -p)) &
-                ((y <= p)))
-        mask += (x >= 0)
-        mask += (y <= 0)
+        mask = ((x >= -p)) & ((y <= p))
+        mask += x >= 0
+        mask += y <= 0
         # reflect that mask to
         # make it upper-right:
         mask = mask[::-1, ::-1]
         # kernel masked:
         kernel[mask] = 0
     else:
-        raise ValueError(
-            "Kernel-type {} has not been implemented yet".format(ktype))
+        raise ValueError("Kernel-type {} has not been implemented yet".format(ktype))
     return kernel
 
 
@@ -939,9 +937,10 @@ def coarsen(reduction, x, axes, trim_excess=False):
             axes[i] = 1
 
     if trim_excess:
-        ind = tuple(slice(0, -(d % axes[i]))
-                    if d % axes[i] else slice(None, None)
-                    for i, d in enumerate(x.shape))
+        ind = tuple(
+            slice(0, -(d % axes[i])) if d % axes[i] else slice(None, None)
+            for i, d in enumerate(x.shape)
+        )
         x = x[ind]
 
     # (10, 10) -> (5, 2, 5, 2)
@@ -955,17 +954,16 @@ def smooth(y, box_pts):
     try:
         from astropy.convolution import convolve
     except ImportError:
-        raise ImportError(
-            "The astropy module is required to use this function")
-    box = np.ones(box_pts)/box_pts
+        raise ImportError("The astropy module is required to use this function")
+    box = np.ones(box_pts) / box_pts
     # also: None, fill, wrap, extend
-    y_smooth = convolve(y, box, boundary='extend')
+    y_smooth = convolve(y, box, boundary="extend")
     return y_smooth
 
 
 def infer_mask2D(mat):
     if mat.shape[0] != mat.shape[1]:
-        raise ValueError('matix must be symmetric!')
+        raise ValueError("matix must be symmetric!")
     fill_na(mat, value=0, copy=False)
     sum0 = np.sum(mat, axis=0) > 0
     mask = sum0[:, None] * sum0[None, :]
@@ -974,25 +972,25 @@ def infer_mask2D(mat):
 
 def remove_good_singletons(mat, mask=None, returnMask=False):
     mat = mat.copy()
-    if mask == None:
+    if mask is None:
         mask = infer_mask2D(mat)
-    badBins = (np.sum(mask, axis=0) == 0)
+    badBins = np.sum(mask, axis=0) == 0
     goodBins = badBins == 0
-    good_singletons = ((goodBins * smooth(goodBins, 3)) == 1/3)
+    good_singletons = (goodBins * smooth(goodBins, 3)) == 1 / 3
     mat[good_singletons, :] = np.nan
     mat[:, good_singletons] = np.nan
     mask[good_singletons, :] = 0
     mask[:, good_singletons] = 0
-    if returnMask == True:
+    if returnMask:
         return mat, mask
     else:
         return mat
 
 
-def interpolate_bad_singletons(mat, mask=None,
-                               fillDiagonal=True, returnMask=False,
-                               secondPass=True, verbose=False):
-    ''' interpolate singleton missing bins for visualization
+def interpolate_bad_singletons(
+    mat, mask=None, fillDiagonal=True, returnMask=False, secondPass=True, verbose=False
+):
+    """ interpolate singleton missing bins for visualization
 
     Examples
     --------
@@ -1005,15 +1003,16 @@ def interpolate_bad_singletons(mat, mask=None,
             interpolate_bad_singletons(remove_good_singletons(mat))), vmax=maxval, fignum=False)
     plt.set_cmap('fall');
     plt.show()
-    '''
+    """
     mat = mat.copy()
     if mask is None:
         mask = infer_mask2D(mat)
-    antimask = (~mask)
-    badBins = (np.sum(mask, axis=0) == 0)
-    singletons = ((badBins * smooth(badBins == 0, 3)) > 1/3)
-    bb_minus_singletons = (badBins.astype(
-        'int8')-singletons.astype('int8')).astype('bool')
+    antimask = ~mask
+    badBins = np.sum(mask, axis=0) == 0
+    singletons = (badBins * smooth(badBins == 0, 3)) > 1 / 3
+    bb_minus_singletons = (badBins.astype("int8") - singletons.astype("int8")).astype(
+        "bool"
+    )
 
     mat[antimask] = np.nan
     locs = np.zeros(np.shape(mat))
@@ -1024,61 +1023,77 @@ def interpolate_bad_singletons(mat, mask=None,
     locs = np.nonzero(locs)  # np.isnan(mat))
     interpvals = np.zeros(np.shape(mat))
     if verbose:
-        print('initial pass to interpolate:', len(locs[0]))
-    for loc in zip(locs[0],  locs[1]):
+        print("initial pass to interpolate:", len(locs[0]))
+    for loc in zip(locs[0], locs[1]):
         i, j = loc
         if loc[0] > loc[1]:
-            if (loc[0] > 0) and (loc[1] > 0) and (loc[0] < len(mat)-1) and (loc[1] < len(mat)-1):
-                interpvals[i, j] = np.nanmean([mat[i-1, j-1], mat[i+1, j+1]])
+            if (
+                (loc[0] > 0)
+                and (loc[1] > 0)
+                and (loc[0] < len(mat) - 1)
+                and (loc[1] < len(mat) - 1)
+            ):
+                interpvals[i, j] = np.nanmean([mat[i - 1, j - 1], mat[i + 1, j + 1]])
             elif loc[0] == 0:
-                interpvals[i, j] = np.nanmean([mat[i, j-1], mat[i, j+1]])
+                interpvals[i, j] = np.nanmean([mat[i, j - 1], mat[i, j + 1]])
             elif loc[1] == 0:
-                interpvals[i, j] = np.nanmean([mat[i-1, j], mat[i+1, j]])
-            elif loc[0] == (len(mat)-1):
-                interpvals[i, j] = np.nanmean([mat[i, j-1], mat[i, j+1]])
-            elif loc[1] == (len(mat)-1):
-                interpvals[i, j] = np.nanmean([mat[i-1, j], mat[i+1, j]])
-    interpvals = interpvals+interpvals.T
+                interpvals[i, j] = np.nanmean([mat[i - 1, j], mat[i + 1, j]])
+            elif loc[0] == (len(mat) - 1):
+                interpvals[i, j] = np.nanmean([mat[i, j - 1], mat[i, j + 1]])
+            elif loc[1] == (len(mat) - 1):
+                interpvals[i, j] = np.nanmean([mat[i - 1, j], mat[i + 1, j]])
+    interpvals = interpvals + interpvals.T
     mat[locs] = interpvals[locs]
     mask[locs] = 1
 
-    if secondPass == True:
+    if secondPass:
         locs = np.nonzero(np.isnan(interpvals))  # np.isnan(mat))
         interpvals2 = np.zeros(np.shape(mat))
         if verbose:
-            print('still remaining: ', len(locs[0]))
-        for loc in zip(locs[0],  locs[1]):
+            print("still remaining: ", len(locs[0]))
+        for loc in zip(locs[0], locs[1]):
             i, j = loc
             if loc[0] > loc[1]:
-                if (loc[0] > 0) and (loc[1] > 0) and (loc[0] < len(mat)-1) and (loc[1] < len(mat)-1):
+                if (
+                    (loc[0] > 0)
+                    and (loc[1] > 0)
+                    and (loc[0] < len(mat) - 1)
+                    and (loc[1] < len(mat) - 1)
+                ):
                     interpvals2[i, j] = np.nanmean(
-                        [mat[i-1, j-1], mat[i+1, j+1]])
+                        [mat[i - 1, j - 1], mat[i + 1, j + 1]]
+                    )
                 elif loc[0] == 0:
-                    interpvals2[i, j] = np.nanmean([mat[i, j-1], mat[i, j+1]])
+                    interpvals2[i, j] = np.nanmean([mat[i, j - 1], mat[i, j + 1]])
                 elif loc[1] == 0:
-                    interpvals2[i, j] = np.nanmean([mat[i-1, j], mat[i+1, j]])
-                elif loc[0] == (len(mat)-1):
-                    interpvals2[i, j] = np.nanmean([mat[i, j-1], mat[i, j+1]])
-                elif loc[1] == (len(mat)-1):
-                    interpvals2[i, j] = np.nanmean([mat[i-1, j], mat[i+1, j]])
-        interpvals2 = interpvals2+interpvals2.T
+                    interpvals2[i, j] = np.nanmean([mat[i - 1, j], mat[i + 1, j]])
+                elif loc[0] == (len(mat) - 1):
+                    interpvals2[i, j] = np.nanmean([mat[i, j - 1], mat[i, j + 1]])
+                elif loc[1] == (len(mat) - 1):
+                    interpvals2[i, j] = np.nanmean([mat[i - 1, j], mat[i + 1, j]])
+        interpvals2 = interpvals2 + interpvals2.T
         mat[locs] = interpvals2[locs]
         mask[locs] = 1
 
-    if fillDiagonal == True:
+    if fillDiagonal:
         for i in range(-1, 2):
             set_diag(mat, np.nan, i=i, copy=False)
         for i in range(-1, 2):
             set_diag(mask, 0, i=i, copy=False)
 
-    if returnMask == True:
+    if returnMask:
         return mat, mask
     else:
         return mat
 
 
-def zoom_array(in_array, final_shape, same_sum=False,
-               zoom_function=partial(zoom, order=3), **zoom_kwargs):
+def zoom_array(
+    in_array,
+    final_shape,
+    same_sum=False,
+    zoom_function=partial(zoom, order=3),
+    **zoom_kwargs
+):
     """Rescale an array or image.
 
     Normally, one can use scipy.ndimage.zoom to do array/image rescaling.
@@ -1146,7 +1161,7 @@ def zoom_array(in_array, final_shape, same_sum=False,
         if mult != 1:
             sh = list(rescaled.shape)
             assert sh[ind] % mult == 0
-            newshape = sh[:ind] + [sh[ind] // mult, mult] + sh[ind + 1:]
+            newshape = sh[:ind] + [sh[ind] // mult, mult] + sh[ind + 1 :]
             rescaled.shape = newshape
             rescaled = np.mean(rescaled, axis=ind + 1)
     assert rescaled.shape == final_shape
@@ -1256,7 +1271,7 @@ def adaptive_coarsegrain(ar, countar, cutoff=5, max_levels=8, min_shape=8):
     Norig = ar.shape[0]
     Nlog = np.log2(Norig)
     if not np.allclose(Nlog, np.rint(Nlog)):
-        newN = np.int(2**np.ceil(Nlog))   # next power-of-two sized matrix
+        newN = np.int(2 ** np.ceil(Nlog))  # next power-of-two sized matrix
         newar = np.empty((newN, newN), dtype=float)  # fitting things in there
         newar[:] = np.nan
         newcountar = np.zeros((newN, newN), dtype=float)
@@ -1273,7 +1288,7 @@ def adaptive_coarsegrain(ar, countar, cutoff=5, max_levels=8, min_shape=8):
     assert countar.shape == ar.shape
 
     # We will be working with three arrays.
-    ar_cg = [ar]   # actual Hi-C data
+    ar_cg = [ar]  # actual Hi-C data
     countar_cg = [countar]  # counts contributing to Hi-C data (raw Hi-C reads)
     armask_cg = [armask]  # mask of "valid" pixels of the heatmap
 

--- a/cooltools/lib/peaks.py
+++ b/cooltools/lib/peaks.py
@@ -4,8 +4,8 @@ import warnings
 import numpy as np
 
 
-def find_peak_prominence(arr, max_dist = None):
-    '''Find the local maxima of an array and their prominence.
+def find_peak_prominence(arr, max_dist=None):
+    """Find the local maxima of an array and their prominence.
     The prominence of a peak is defined as the maximal difference between the
     height of the peak and the lowest point in the range until a higher peak.
 
@@ -23,12 +23,11 @@ def find_peak_prominence(arr, max_dist = None):
 
     proms : numpy.array
         The prominence of the detected maxima.
-    '''
+    """
 
     arr = np.asarray(arr)
     n = len(arr)
     max_dist = len(arr) if max_dist is None else int(max_dist)
-
 
     # Finding all local minima and maxima (i.e. points the are lower/higher than
     # both immediate non-nan neighbors).
@@ -53,16 +52,16 @@ def find_peak_prominence(arr, max_dist = None):
     # For each maximum, find the position of a higher peak on the left and
     # on the right. If there are no higher peaks within the `max_dist` range,
     # just use the position `max_dist` away.
-    left_maxs =  -1 * np.ones(len(loc_max_poss), dtype=np.int)
+    left_maxs = -1 * np.ones(len(loc_max_poss), dtype=np.int)
     right_maxs = -1 * np.ones(len(loc_max_poss), dtype=np.int)
 
     for i, pos in enumerate(loc_max_poss):
-        for j in range(pos-1,-1,-1):
+        for j in range(pos - 1, -1, -1):
             if (arr[j] > arr[pos]) or (pos - j > max_dist):
                 left_maxs[i] = j
                 break
 
-        for j in range(pos+1, n):
+        for j in range(pos + 1, n):
             if (arr[j] > arr[pos]) or (j - pos > max_dist):
                 right_maxs[i] = j
                 break
@@ -70,23 +69,27 @@ def find_peak_prominence(arr, max_dist = None):
     # Find the prominence of each peak with respect of the lowest point
     # between the peak and the adjacent higher peaks, on the left and the right
     # separately.
-    left_max_proms = np.array([
-        (arr[pos] - np.nanmin(arr[left_maxs[i]:pos])
-            if (left_maxs[i] >= 0)
-            else np.nan
-        )
+    left_max_proms = np.array(
+        [
+            (
+                arr[pos] - np.nanmin(arr[left_maxs[i] : pos])
+                if (left_maxs[i] >= 0)
+                else np.nan
+            )
+            for i, pos in enumerate(loc_max_poss)
+        ]
+    )
 
-        for i, pos in enumerate(loc_max_poss)
-    ])
-
-    right_max_proms = np.array([
-        (arr[pos] - np.nanmin(arr[pos:right_maxs[i]])
-            if (right_maxs[i] >= 0)
-            else np.nan
-        )
-
-        for i, pos in enumerate(loc_max_poss)
-    ])
+    right_max_proms = np.array(
+        [
+            (
+                arr[pos] - np.nanmin(arr[pos : right_maxs[i]])
+                if (right_maxs[i] >= 0)
+                else np.nan
+            )
+            for i, pos in enumerate(loc_max_poss)
+        ]
+    )
 
     # In 1D, the topographic definition of the prominence of a peak reduces to
     # the minimum of the left-side and right-side prominence.
@@ -94,9 +97,7 @@ def find_peak_prominence(arr, max_dist = None):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)
 
-        max_proms = np.nanmin(
-            np.vstack([left_max_proms, right_max_proms]),
-            axis=0)
+        max_proms = np.nanmin(np.vstack([left_max_proms, right_max_proms]), axis=0)
 
     # The global maximum, by definition, does not have higher peaks around it and
     # thus its prominence is explicitly defined with respect to the lowest local
@@ -105,24 +106,20 @@ def find_peak_prominence(arr, max_dist = None):
     # to the lowest point within the `max_dist` range.
     # If no local minima are within the `max_dist` range, just use the
     # lowest point.
-    global_max_mask = (left_maxs == -1) & (right_maxs==-1)
+    global_max_mask = (left_maxs == -1) & (right_maxs == -1)
     if (global_max_mask).sum() > 0:
         global_max_idx = np.where(global_max_mask)[0][0]
         global_max_pos = loc_max_poss[global_max_idx]
-        neighbor_loc_mins = (
-            (loc_min_poss >= global_max_pos - max_dist)
-          & (loc_min_poss < global_max_pos + max_dist)
+        neighbor_loc_mins = (loc_min_poss >= global_max_pos - max_dist) & (
+            loc_min_poss < global_max_pos + max_dist
         )
         if np.any(neighbor_loc_mins):
-            max_proms[global_max_idx] = (
-                arr[global_max_pos]
-                - np.nanmin(arr[loc_min_poss[neighbor_loc_mins]])
+            max_proms[global_max_idx] = arr[global_max_pos] - np.nanmin(
+                arr[loc_min_poss[neighbor_loc_mins]]
             )
         else:
-            max_proms[global_max_idx] = (
-                arr[global_max_pos]
-                - np.nanmin(arr[max(global_max_pos - max_dist, 0):
-                                global_max_pos + max_dist])
+            max_proms[global_max_idx] = arr[global_max_pos] - np.nanmin(
+                arr[max(global_max_pos - max_dist, 0) : global_max_pos + max_dist]
             )
 
     return loc_max_poss, max_proms
@@ -165,10 +162,10 @@ def peakdet(arr, min_prominence):
     arr = np.asarray(arr)
 
     if not np.isscalar(min_prominence):
-        raise Exception('Input argument delta must be a scalar')
+        raise Exception("Input argument delta must be a scalar")
 
     if min_prominence <= 0:
-        raise Exception('Input argument delta must be positive')
+        raise Exception("Input argument delta must be positive")
 
     mn, mx = np.inf, -np.inf
     mnpos, mxpos = np.nan, np.nan
@@ -206,8 +203,8 @@ def find_peak_prominence_iterative(
     max_prom=None,
     steps_prom=1000,
     log_space_proms=True,
-    min_n_peak_pairs=5
-    ):
+    min_n_peak_pairs=5,
+):
     """Finds the minima/maxima of an array using the peakdet algorithm at
     different values of the threshold prominence. For each location, returns
     the maximal threshold prominence at which it is called as a minimum/maximum.
@@ -237,11 +234,13 @@ def find_peak_prominence_iterative(
     minproms, maxproms : numpy.array
         The prominence of detected minima and maxima.
     """
-    if (((min_prom is None) and (max_prom is not None))
-        or ((min_prom is not None) and (max_prom is None))):
+    if ((min_prom is None) and (max_prom is not None)) or (
+        (min_prom is not None) and (max_prom is None)
+    ):
         raise Exception(
-            'Please, provide either both min_prom and max_prom or '
-            'none to infer these values from the data.')
+            "Please, provide either both min_prom and max_prom or "
+            "none to infer these values from the data."
+        )
 
     if (min_prom is None) and (max_prom is None):
         arr_sorted = np.sort(arr)
@@ -249,25 +248,18 @@ def find_peak_prominence_iterative(
         max_prom = arr_sorted[-1] - arr_sorted[0]
 
         diffs = np.diff(arr_sorted)
-        min_prom = diffs[diffs !=0].min()
+        min_prom = diffs[diffs != 0].min()
 
     if log_space_proms:
-        proms = 10**np.linspace(
-            np.log10(min_prom),
-            np.log10(max_prom),
-            steps_prom)
+        proms = 10 ** np.linspace(np.log10(min_prom), np.log10(max_prom), steps_prom)
     else:
-        proms = np.linspace(
-            min_prom,
-            max_prom,
-            steps_prom)
+        proms = np.linspace(min_prom, max_prom, steps_prom)
 
     minproms = np.nan * np.ones_like(arr)
     maxproms = np.nan * np.ones_like(arr)
     for p in proms:
         minidxs, maxidxs = peakdet(arr, p)
-        if ((len(minidxs) >= min_n_peak_pairs)
-            and (len(minidxs) >= min_n_peak_pairs)):
+        if (len(minidxs) >= min_n_peak_pairs) and (len(minidxs) >= min_n_peak_pairs):
 
             valid_mins = minidxs[np.isfinite(arr[minidxs])]
             minproms[valid_mins] = p
@@ -276,4 +268,3 @@ def find_peak_prominence_iterative(
             maxproms[valid_maxs] = p
 
     return minproms, maxproms
-

--- a/cooltools/lib/plotting.py
+++ b/cooltools/lib/plotting.py
@@ -9,51 +9,63 @@ import numpy as np
 
 
 PALETTES = {
-    'fall': np.array((
-        (255, 255, 255),
-        (255, 255, 204),
-        (255, 237, 160),
-        (254, 217, 118),
-        (254, 178, 76),
-        (253, 141, 60),
-        (252, 78, 42),
-        (227, 26, 28),
-        (189, 0, 38),
-        (128, 0, 38),
-        (0, 0, 0)
-    ))/255,
-    'blues': np.array((
-        (255, 255, 255),
-        (180, 204, 225),
-        (116, 169, 207),
-        (54, 144, 192),
-        (5, 112, 176),
-        (4, 87, 135),
-        (3, 65, 100),
-        (2, 40, 66),
-        (1, 20, 30),
-        (0, 0, 0)
-    ))/255,
-    'acidblues': np.array((
-        (255, 255, 255),
-        (162, 192, 222),
-        (140, 137, 187),
-        (140, 87, 167),
-        (140, 45, 143),
-        (120, 20, 120),
-        (90, 15, 90),
-        (60, 10, 60),
-        (30, 5, 30),
-        (0, 0, 0)
-    ))/255,
-    'nmeth': np.array((
-        (236, 250, 255),
-        (148, 189, 217),
-        (118, 169, 68),
-        (131, 111, 43),
-        (122, 47, 25),
-        (41, 0, 20)
-    ))/255,
+    "fall": np.array(
+        (
+            (255, 255, 255),
+            (255, 255, 204),
+            (255, 237, 160),
+            (254, 217, 118),
+            (254, 178, 76),
+            (253, 141, 60),
+            (252, 78, 42),
+            (227, 26, 28),
+            (189, 0, 38),
+            (128, 0, 38),
+            (0, 0, 0),
+        )
+    )
+    / 255,
+    "blues": np.array(
+        (
+            (255, 255, 255),
+            (180, 204, 225),
+            (116, 169, 207),
+            (54, 144, 192),
+            (5, 112, 176),
+            (4, 87, 135),
+            (3, 65, 100),
+            (2, 40, 66),
+            (1, 20, 30),
+            (0, 0, 0),
+        )
+    )
+    / 255,
+    "acidblues": np.array(
+        (
+            (255, 255, 255),
+            (162, 192, 222),
+            (140, 137, 187),
+            (140, 87, 167),
+            (140, 45, 143),
+            (120, 20, 120),
+            (90, 15, 90),
+            (60, 10, 60),
+            (30, 5, 30),
+            (0, 0, 0),
+        )
+    )
+    / 255,
+    "nmeth": np.array(
+        (
+            (236, 250, 255),
+            (148, 189, 217),
+            (118, 169, 68),
+            (131, 111, 43),
+            (122, 47, 25),
+            (41, 0, 20),
+        )
+    )
+    / 255,
 }
 
 
@@ -61,16 +73,16 @@ def list_to_colormap(color_list, name=None):
     color_list = np.array(color_list)
     if color_list.min() < 0:
         raise ValueError("Colors should be 0 to 1, or 0 to 255")
-    if color_list.max() > 1.:
+    if color_list.max() > 1.0:
         if color_list.max() > 255:
             raise ValueError("Colors should be 0 to 1 or 0 to 255")
         else:
-            color_list = color_list / 255.
+            color_list = color_list / 255.0
     return mpl.colors.LinearSegmentedColormap.from_list(name, color_list, 256)
 
 
 def get_cmap(name):
-    is_reversed = name.endswith('_r')
+    is_reversed = name.endswith("_r")
     try:
         if is_reversed:
             pal = PALETTES[name[:-2]][::-1]
@@ -90,31 +102,21 @@ def _register_cmaps():
 _register_cmaps()
 
 
-def gridspec_inches(
-    wcols,
-    hrows,
-    fig_kwargs={}):
+def gridspec_inches(wcols, hrows, fig_kwargs={}):
 
-    fig_height_inches = (
-        sum(hrows)
-        )
+    fig_height_inches = sum(hrows)
 
-    fig_width_inches = (
-        sum(wcols)
-        )
+    fig_width_inches = sum(wcols)
 
     fig = plt.figure(
-        figsize=(fig_width_inches,fig_height_inches),
+        figsize=(fig_width_inches, fig_height_inches),
         subplotpars=mpl.figure.SubplotParams(
-            left=0,
-            right=1,
-            bottom=0,
-            top=1,
-            wspace =0,
-            hspace = 0.0),
-        #frameon=False,
-        **fig_kwargs)
-    fig.set_size_inches(fig_width_inches,fig_height_inches,forward=True)
+            left=0, right=1, bottom=0, top=1, wspace=0, hspace=0.0
+        ),
+        # frameon=False,
+        **fig_kwargs
+    )
+    fig.set_size_inches(fig_width_inches, fig_height_inches, forward=True)
 
     gs = mpl.gridspec.GridSpec(
         len(hrows),
@@ -126,8 +128,7 @@ def gridspec_inches(
         wspace=0,
         hspace=0,
         width_ratios=wcols,
-        height_ratios=hrows
-        )
+        height_ratios=hrows,
+    )
 
     return fig, gs
-

--- a/cooltools/lib/runlength.py
+++ b/cooltools/lib/runlength.py
@@ -155,7 +155,7 @@ def simplify(starts, lengths, values, minlength=None):
     of the same value.
 
     """
-    starts, lengths, values = fill_gaps(starts, lengths, values, minlength)
+    starts, lengths, values = fillgaps(starts, lengths, values, minlength)
     n = starts[-1] + lengths[-1]
 
     is_nontrivial = lengths > 0

--- a/cooltools/sample.py
+++ b/cooltools/sample.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 
-import cooler, cooler.tools
+import cooler
+import cooler.tools
 
 
 def sample_pixels_approx(pixels, frac):

--- a/cooltools/sample.py
+++ b/cooltools/sample.py
@@ -5,35 +5,32 @@ import cooler, cooler.tools
 
 
 def sample_pixels_approx(pixels, frac):
-    pixels['count'] = np.random.binomial(pixels['count'], frac)
-    mask = pixels['count'] > 0
+    pixels["count"] = np.random.binomial(pixels["count"], frac)
+    mask = pixels["count"] > 0
 
     if issubclass(type(pixels), pd.DataFrame):
         pixels = pixels[mask]
     elif issubclass(type(pixels), dict):
-        pixels = {k:arr[mask] for k, arr in pixels.items()}
+        pixels = {k: arr[mask] for k, arr in pixels.items()}
     return pixels
 
 
 def sample_pixels_exact(pixels, count):
-    cumcount = np.cumsum(np.asarray(pixels['count']))
+    cumcount = np.cumsum(np.asarray(pixels["count"]))
     total = cumcount[-1]
     n_pixels = cumcount.shape[0]
 
     # sample a given number of distinct contacts
-    random_contacts = np.random.choice(
-        total,
-        size=count,
-        replace=False)
+    random_contacts = np.random.choice(total, size=count, replace=False)
 
     # find where those contacts live in the cumcount array
-    loc = np.searchsorted(cumcount, random_contacts, side='right')
+    loc = np.searchsorted(cumcount, random_contacts, side="right")
 
     # re-bin those locations to get new counts
     new_counts = np.bincount(loc, minlength=n_pixels)
 
-    pixels['count'] = new_counts
-    mask = pixels['count'] > 0
+    pixels["count"] = new_counts
+    mask = pixels["count"] > 0
     if issubclass(type(pixels), pd.DataFrame):
         pixels = pixels[mask]
     elif issubclass(type(pixels), dict):
@@ -42,11 +39,18 @@ def sample_pixels_exact(pixels, count):
 
 
 def _extract_pixel_chunk(chunk):
-    return chunk['pixels']
+    return chunk["pixels"]
 
 
-def sample_cooler(clr, out_clr_path, count=None, frac=None, exact=False,
-                  map_func=map, chunksize=int(1e7)):
+def sample_cooler(
+    clr,
+    out_clr_path,
+    count=None,
+    frac=None,
+    exact=False,
+    map_func=map,
+    chunksize=int(1e7),
+):
     """
     Pick a random subset of contacts from a Hi-C map.
 
@@ -83,30 +87,29 @@ def sample_cooler(clr, out_clr_path, count=None, frac=None, exact=False,
         clr = cooler.Cooler(clr)
 
     if count is not None and frac is None:
-        frac = count / clr.info['sum']
+        frac = count / clr.info["sum"]
     elif count is None and frac is not None:
-        count = np.round(frac * clr.info['sum'])
+        count = np.round(frac * clr.info["sum"])
     else:
-        raise ValueError('Either frac or tot_count must be specified!')
+        raise ValueError("Either frac or tot_count must be specified!")
 
     if frac >= 1.0:
-        raise ValueError('The number of contacts in a sample cannot exceed '
-                         'that in the original dataset.')
+        raise ValueError(
+            "The number of contacts in a sample cannot exceed "
+            "that in the original dataset."
+        )
 
     if exact:
         pixels = sample_pixels_exact(clr.pixels()[:], count)
-        cooler.create_cooler(
-            out_clr_path, clr.bins()[:], pixels, ordered=True)
+        cooler.create_cooler(out_clr_path, clr.bins()[:], pixels, ordered=True)
 
     else:
         pipeline = (
-            cooler.tools.split(clr,
-                               include_bins=False,
-                               map=map_func,
-                               chunksize=chunksize)
+            cooler.tools.split(
+                clr, include_bins=False, map=map_func, chunksize=chunksize
+            )
             .pipe(_extract_pixel_chunk)
             .pipe(sample_pixels_approx, frac=frac)
         )
 
-        cooler.create_cooler(
-            out_clr_path, clr.bins()[:], iter(pipeline), ordered=True)
+        cooler.create_cooler(out_clr_path, clr.bins()[:], iter(pipeline), ordered=True)

--- a/cooltools/snipping.py
+++ b/cooltools/snipping.py
@@ -12,8 +12,9 @@ import cooler
 from .lib.numutils import LazyToeplitz
 
 
-def make_bin_aligned_windows(binsize, chroms, centers_bp, flank_bp=0,
-                             region_start_bp=0, ignore_index=False):
+def make_bin_aligned_windows(
+    binsize, chroms, centers_bp, flank_bp=0, region_start_bp=0, ignore_index=False
+):
     """
     Convert genomic loci into bin spans on a fixed bin-size segmentation of a
     genomic region. Window limits are adjusted to align with bin edges.
@@ -41,8 +42,7 @@ def make_bin_aligned_windows(binsize, chroms, centers_bp, flank_bp=0,
 
     """
     if not (flank_bp % binsize == 0):
-        raise ValueError(
-            "Flanking distance must be divisible by the bin size.")
+        raise ValueError("Flanking distance must be divisible by the bin size.")
 
     if isinstance(chroms, pd.Series) and not ignore_index:
         index = chroms.index
@@ -69,11 +69,11 @@ def make_bin_aligned_windows(binsize, chroms, centers_bp, flank_bp=0,
     lo = left_bin - flank_bin
     hi = right_bin + flank_bin + 1
     windows = pd.DataFrame(index=index)
-    windows['chrom'] = chroms
-    windows['start'] = lo * binsize
-    windows['end'] = hi * binsize
-    windows['lo'] = lo
-    windows['hi'] = hi
+    windows["chrom"] = chroms
+    windows["start"] = lo * binsize
+    windows["end"] = hi * binsize
+    windows["lo"] = lo
+    windows["hi"] = hi
     return windows
 
 
@@ -84,55 +84,55 @@ def assign_regions(features, supports):
     features = features.copy()
 
     # on-diagonal features
-    if 'chrom' in features.columns:
+    if "chrom" in features.columns:
         for i, region in enumerate(supports):
             if len(region) == 3:
-                sel = (features.chrom == region[0])
-                sel &= (features.end >= region[1])
+                sel = features.chrom == region[0]
+                sel &= features.end >= region[1]
                 if region[2] is not None:
-                    sel &= (features.start < region[2])
+                    sel &= features.start < region[2]
 
-                features.loc[sel, 'region'] = i
+                features.loc[sel, "region"] = i
 
             elif len(region) == 2:
                 region1, region2 = region
-                sel1 = (features.chrom == region1[0])
-                sel1 &= (features.end >= region1[1])
+                sel1 = features.chrom == region1[0]
+                sel1 &= features.end >= region1[1]
                 if region1[2] is not None:
-                    sel1 &= (features.start < region1[2])
+                    sel1 &= features.start < region1[2]
 
-                sel2 = (features.chrom == region2[0])
-                sel2 &= (features.end >= region2[1])
+                sel2 = features.chrom == region2[0]
+                sel2 &= features.end >= region2[1]
                 if region2[2] is not None:
-                    sel2 &= (features.start < region2[2])
+                    sel2 &= features.start < region2[2]
 
-                features.loc[(sel1 | sel2), 'region'] = i
+                features.loc[(sel1 | sel2), "region"] = i
 
     # off-diagonal features
-    elif 'chrom1' in features.columns:
+    elif "chrom1" in features.columns:
         for i, region in enumerate(supports):
             if len(region) == 3:
                 region1, region2 = region, region
             elif len(region) == 2:
                 region1, region2 = region[0], region[1]
 
-            sel1 = (features.chrom1 == region1[0])
-            sel1 &= (features.end1 >= region1[1])
+            sel1 = features.chrom1 == region1[0]
+            sel1 &= features.end1 >= region1[1]
             if region1[2] is not None:
-                sel1 &= (features.start1 < region1[2])
+                sel1 &= features.start1 < region1[2]
 
-            sel2 = (features.chrom2 == region2[0])
-            sel2 &= (features.end2 >= region2[1])
+            sel2 = features.chrom2 == region2[0]
+            sel2 &= features.end2 >= region2[1]
             if region2[2] is not None:
-                sel2 &= (features.start2 < region2[2])
+                sel2 &= features.start2 < region2[2]
 
-            features.loc[(sel1 | sel2), 'region'] = i
+            features.loc[(sel1 | sel2), "region"] = i
     else:
-        raise ValueError('Could not parse `features` data frame.')
+        raise ValueError("Could not parse `features` data frame.")
 
-    features['region'] = features['region'].map(
-        lambda i: '{}:{}-{}'.format(*supports[int(i)]),
-        na_action='ignore')
+    features["region"] = features["region"].map(
+        lambda i: "{}:{}-{}".format(*supports[int(i)]), na_action="ignore"
+    )
     return features
 
 
@@ -145,21 +145,20 @@ def _pileup(data_select, data_snip, arg):
         region1 = region2 = bioframe.parse_region_string(support)
 
     # check if features are on- or off-diagonal
-    if 'start' in feature_group:
-        s1 = feature_group['start'].values
-        e1 = feature_group['end'].values
+    if "start" in feature_group:
+        s1 = feature_group["start"].values
+        e1 = feature_group["end"].values
         s2, e2 = s1, e1
     else:
-        s1 = feature_group['start1'].values
-        e1 = feature_group['end1'].values
-        s2 = feature_group['start2'].values
-        e2 = feature_group['end2'].values
+        s1 = feature_group["start1"].values
+        e1 = feature_group["end1"].values
+        s2 = feature_group["start2"].values
+        e2 = feature_group["end2"].values
 
     data = data_select(region1, region2)
-    stack = list(map(partial(data_snip, data, region1, region2),
-                     zip(s1, e1, s2, e2)))
+    stack = list(map(partial(data_snip, data, region1, region2), zip(s1, e1, s2, e2)))
 
-    return np.dstack(stack), feature_group['_rank'].values
+    return np.dstack(stack), feature_group["_rank"].values
 
 
 def pileup(features, data_select, data_snip, map=map):
@@ -186,17 +185,20 @@ def pileup(features, data_select, data_snip, map=map):
     """
     if features.region.isnull().any():
         raise ValueError(
-            'Drop features with no region assignment before calling pileup!')
+            "Drop features with no region assignment before calling pileup!"
+        )
 
     features = features.copy()
-    features['_rank'] = range(len(features))
+    features["_rank"] = range(len(features))
 
     # cumul_stack = []
     # orig_rank = []
-    cumul_stack, orig_rank = zip(*map(
-        partial(_pileup, data_select, data_snip),
-        features.groupby('region', sort=False)
-    ))
+    cumul_stack, orig_rank = zip(
+        *map(
+            partial(_pileup, data_select, data_snip),
+            features.groupby("region", sort=False),
+        )
+    )
 
     # Restore the original rank of the input features
     cumul_stack = np.dstack(cumul_stack)
@@ -215,25 +217,25 @@ def pair_sites(sites, separation, slop):
     """
     from bioframe.tools import tsv, bedtools
 
-    mids = (sites['start'] + sites['end']) // 2
-    left_hand = sites[['chrom']].copy()
-    left_hand['start'] = mids - separation - slop
-    left_hand['end'] = mids - separation + slop
-    left_hand['site_id'] = left_hand.index
-    left_hand['direction'] = 'L'
-    left_hand['snip_mid'] = mids
-    left_hand['snip_strand'] = sites['strand']
+    mids = (sites["start"] + sites["end"]) // 2
+    left_hand = sites[["chrom"]].copy()
+    left_hand["start"] = mids - separation - slop
+    left_hand["end"] = mids - separation + slop
+    left_hand["site_id"] = left_hand.index
+    left_hand["direction"] = "L"
+    left_hand["snip_mid"] = mids
+    left_hand["snip_strand"] = sites["strand"]
 
-    right_hand = sites[['chrom']].copy()
-    right_hand['start'] = mids + separation - slop
-    right_hand['end'] = mids + separation + slop
-    right_hand['site_id'] = right_hand.index
-    right_hand['direction'] = 'R'
-    right_hand['snip_mid'] = mids
-    right_hand['snip_strand'] = sites['strand']
+    right_hand = sites[["chrom"]].copy()
+    right_hand["start"] = mids + separation - slop
+    right_hand["end"] = mids + separation + slop
+    right_hand["site_id"] = right_hand.index
+    right_hand["direction"] = "R"
+    right_hand["snip_mid"] = mids
+    right_hand["snip_strand"] = sites["strand"]
 
     # ignore out-of-bounds hands
-    mask = (left_hand['start'] > 0) & (right_hand['start'] > 0)
+    mask = (left_hand["start"] > 0) & (right_hand["start"] > 0)
     left_hand = left_hand[mask].copy()
     right_hand = right_hand[mask].copy()
 
@@ -241,8 +243,9 @@ def pair_sites(sites, separation, slop):
     # with left hands (right anchor site)
     with tsv(right_hand) as R, tsv(left_hand) as L:
         out = bedtools.intersect(a=R.name, b=L.name, wa=True, wb=True)
-        out.columns = ([c+'_r' for c in right_hand.columns] +
-                       [c+'_l' for c in left_hand.columns])
+        out.columns = [c + "_r" for c in right_hand.columns] + [
+            c + "_l" for c in left_hand.columns
+        ]
     return out
 
 
@@ -253,18 +256,15 @@ class CoolerSnipper:
         self.offsets = {}
         self.pad = True
         self.cooler_opts = {} if cooler_opts is None else cooler_opts
-        self.cooler_opts.setdefault('sparse', True)
+        self.cooler_opts.setdefault("sparse", True)
 
     def select(self, region1, region2):
-        self.offsets[region1] = self.clr.offset(
-            region1) - self.clr.offset(region1[0])
-        self.offsets[region2] = self.clr.offset(
-            region2) - self.clr.offset(region2[0])
-        self._isnan1 = np.isnan(self.clr.bins()['weight'].fetch(region1).values)
-        self._isnan2 = np.isnan(self.clr.bins()['weight'].fetch(region2).values)
-        matrix = (self.clr.matrix(**self.cooler_opts)
-                          .fetch(region1, region2))
-        if self.cooler_opts['sparse']:
+        self.offsets[region1] = self.clr.offset(region1) - self.clr.offset(region1[0])
+        self.offsets[region2] = self.clr.offset(region2) - self.clr.offset(region2[0])
+        self._isnan1 = np.isnan(self.clr.bins()["weight"].fetch(region1).values)
+        self._isnan2 = np.isnan(self.clr.bins()["weight"].fetch(region2).values)
+        matrix = self.clr.matrix(**self.cooler_opts).fetch(region1, region2)
+        if self.cooler_opts["sparse"]:
             matrix = matrix.tocsr()
         return matrix
 
@@ -301,8 +301,8 @@ class CoolerSnipper:
             j0 = max(lo2, 0)
             j1 = min(hi2, n)
             snippet = np.full((dm, dn), np.nan)
-#             snippet[pad_bottom:pad_top,
-#                     pad_left:pad_right] = matrix[i0:i1, j0:j1].toarray()
+        #             snippet[pad_bottom:pad_top,
+        #                     pad_left:pad_right] = matrix[i0:i1, j0:j1].toarray()
         else:
             snippet = matrix[lo1:hi1, lo2:hi2].toarray()
             snippet[self._isnan1[lo1:hi1], :] = np.nan
@@ -314,44 +314,53 @@ class ObsExpSnipper:
     def __init__(self, clr, expected, cooler_opts=None):
         self.clr = clr
         self.expected = expected
-        
+
         # Detecting the columns for the detection of regions
         columns = expected.columns
-        assert len(columns)>0
-        if 'chrom' in columns and 'start' in columns and 'end' in columns:
-            self.regions_columns = ['chrom', 'start', 'end'] # Chromosome arms encoded by multiple columns
-        elif 'chrom' in columns:
-            self.regions_columns = ['chrom'] # Chromosomes or regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
-        elif 'region' in columns:
-            self.regions_columns = ['region'] # Regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
-        elif len(columns)>0:
-            self.regions_columns = columns[0] # The first columns is treated as chromosome/region annotation
+        assert len(columns) > 0
+        if "chrom" in columns and "start" in columns and "end" in columns:
+            self.regions_columns = [
+                "chrom",
+                "start",
+                "end",
+            ]  # Chromosome arms encoded by multiple columns
+        elif "chrom" in columns:
+            self.regions_columns = [
+                "chrom"
+            ]  # Chromosomes or regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
+        elif "region" in columns:
+            self.regions_columns = [
+                "region"
+            ]  # Regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
+        elif len(columns) > 0:
+            self.regions_columns = columns[
+                0
+            ]  # The first columns is treated as chromosome/region annotation
         else:
-            raise ValueError('Expected dataframe has no columns.')
-            
+            raise ValueError("Expected dataframe has no columns.")
+
         self.binsize = self.clr.binsize
         self.offsets = {}
         self.pad = True
         self.cooler_opts = {} if cooler_opts is None else cooler_opts
-        self.cooler_opts.setdefault('sparse', True)
+        self.cooler_opts.setdefault("sparse", True)
 
     def select(self, region1, region2):
-        assert region1==region2, "ObsExpSnipper is implemented for cis contacts only."
-        self.offsets[region1] = self.clr.offset(
-            region1) - self.clr.offset(region1[0])
-        self.offsets[region2] = self.clr.offset(
-            region2) - self.clr.offset(region2[0])
-        matrix = (self.clr.matrix(**self.cooler_opts)
-                          .fetch(region1, region2))
-        if self.cooler_opts['sparse']:
+        assert region1 == region2, "ObsExpSnipper is implemented for cis contacts only."
+        self.offsets[region1] = self.clr.offset(region1) - self.clr.offset(region1[0])
+        self.offsets[region2] = self.clr.offset(region2) - self.clr.offset(region2[0])
+        matrix = self.clr.matrix(**self.cooler_opts).fetch(region1, region2)
+        if self.cooler_opts["sparse"]:
             matrix = matrix.tocsr()
-        self._isnan1 = np.isnan(self.clr.bins()['weight'].fetch(region1).values)
-        self._isnan2 = np.isnan(self.clr.bins()['weight'].fetch(region2).values)
-        self._expected = LazyToeplitz(self.expected
-                .groupby(self.regions_columns)
-                .get_group(region1[0] if len(self.regions_columns)>0 else region1)
-                ['balanced.avg']
-                .values)
+        self._isnan1 = np.isnan(self.clr.bins()["weight"].fetch(region1).values)
+        self._isnan2 = np.isnan(self.clr.bins()["weight"].fetch(region2).values)
+        self._expected = LazyToeplitz(
+            self.expected.groupby(self.regions_columns)
+            .get_group(region1[0] if len(self.regions_columns) > 0 else region1)[
+                "balanced.avg"
+            ]
+            .values
+        )
         return matrix
 
     def snip(self, matrix, region1, region2, tup):
@@ -387,8 +396,8 @@ class ObsExpSnipper:
             j0 = max(lo2, 0)
             j1 = min(hi2, n)
             return np.full((dm, dn), np.nan)
-#             snippet[pad_bottom:pad_top,
-#                     pad_left:pad_right] = matrix[i0:i1, j0:j1].toarray()
+        #             snippet[pad_bottom:pad_top,
+        #                     pad_left:pad_right] = matrix[i0:i1, j0:j1].toarray()
         else:
             snippet = matrix[lo1:hi1, lo2:hi2].toarray()
             snippet[self._isnan1[lo1:hi1], :] = np.nan
@@ -402,37 +411,49 @@ class ExpectedSnipper:
     def __init__(self, clr, expected):
         self.clr = clr
         self.expected = expected
-        
+
         # Detecting the columns for the detection of regions
         columns = expected.columns
-        assert len(columns)>0
-        if 'chrom' in columns and 'start' in columns and 'end' in columns:
-            self.regions_columns = ['chrom', 'start', 'end'] # Chromosome arms encoded by multiple columns
-        elif 'chrom' in columns:
-            self.regions_columns = ['chrom'] # Chromosomes or regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
-        elif 'region' in columns:
-            self.regions_columns = ['region'] # Regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
-        elif len(columns)>0:
-            self.regions_columns = columns[0] # The first columns is treated as chromosome/region annotation
+        assert len(columns) > 0
+        if "chrom" in columns and "start" in columns and "end" in columns:
+            self.regions_columns = [
+                "chrom",
+                "start",
+                "end",
+            ]  # Chromosome arms encoded by multiple columns
+        elif "chrom" in columns:
+            self.regions_columns = [
+                "chrom"
+            ]  # Chromosomes or regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
+        elif "region" in columns:
+            self.regions_columns = [
+                "region"
+            ]  # Regions encoded in string mode: "chr3:XXXXXXX-YYYYYYYY"
+        elif len(columns) > 0:
+            self.regions_columns = columns[
+                0
+            ]  # The first columns is treated as chromosome/region annotation
         else:
-            raise ValueError('Expected dataframe has no columns.')
-            
+            raise ValueError("Expected dataframe has no columns.")
+
         self.binsize = self.clr.binsize
         self.offsets = {}
 
     def select(self, region1, region2):
-        assert region1==region2, "ExpectedSnipper is implemented for cis contacts only."
-        self.offsets[region1] = \
-            self.clr.offset(region1) - self.clr.offset(region1[0])
-        self.offsets[region2] = \
-            self.clr.offset(region2) - self.clr.offset(region2[0])
+        assert (
+            region1 == region2
+        ), "ExpectedSnipper is implemented for cis contacts only."
+        self.offsets[region1] = self.clr.offset(region1) - self.clr.offset(region1[0])
+        self.offsets[region2] = self.clr.offset(region2) - self.clr.offset(region2[0])
         self.m = np.diff(self.clr.extent(region1))
         self.n = np.diff(self.clr.extent(region2))
-        self._expected = LazyToeplitz(self.expected
-                .groupby(self.regions_columns)
-                .get_group(region1[0] if len(self.regions_columns)>0 else region1)
-                ['balanced.avg']
-                .values)
+        self._expected = LazyToeplitz(
+            self.expected.groupby(self.regions_columns)
+            .get_group(region1[0] if len(self.regions_columns) > 0 else region1)[
+                "balanced.avg"
+            ]
+            .values
+        )
         return self._expected
 
     def snip(self, exp, region1, region2, tup):
@@ -446,7 +467,7 @@ class ExpectedSnipper:
         assert hi2 >= 0
         dm, dn = hi1 - lo1, hi2 - lo2
 
-        if (lo1 < 0 or lo2 < 0 or hi1 > self.m or hi2 > self.n):
+        if lo1 < 0 or lo2 < 0 or hi1 > self.m or hi2 > self.n:
             return np.full((dm, dn), np.nan)
 
         snippet = exp[lo1:hi1, lo2:hi2]

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,13 @@ channels:
   - defaults
   - bioconda
 dependencies:
-  - h5py
-  - numpy
   - cython
+  - h5py
   - matplotlib
   - numba
+  - numpy
   - pip
-  - scikit-learn
   - pytables
+  - scikit-learn
   - pip:
     - -r requirements-dev.txt

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+addopts = 
+    --flake8
+    --cov cooltools
+    --cov-config .coveragerc
+    --cov-report term-missing
+    --cov-report html
+    --cov-report xml
+filterwarnings =
+    ignore::PendingDeprecationWarning
+testpaths =
+    tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 pytest
+pytest-flake8
+pytest-cov

--- a/tests/data/make_test_compartments.py
+++ b/tests/data/make_test_compartments.py
@@ -1,55 +1,58 @@
 import subprocess
 import pandas as pd
 import numpy as np
+import h5py
 
 
 # make chromsizes
-with open('./test.chrom.sizes', 'w') as chromsizes:
-    chromsizes.write('chr1\t1000\n')
-    chromsizes.write('chr2\t2000\n')
-    chromsizes.write('chr3\t3000')
+with open("./test.chrom.sizes", "w") as chromsizes:
+    chromsizes.write("chr1\t1000\n")
+    chromsizes.write("chr2\t2000\n")
+    chromsizes.write("chr3\t3000")
 
 BIN_SIZE = 10
 # make bins
 subprocess.check_output(
-    f'cooltools genome binnify ./test.chrom.sizes {BIN_SIZE} > ./test.10.bins',
-    shell=True)
+    f"cooltools genome binnify ./test.chrom.sizes {BIN_SIZE} > ./test.10.bins",
+    shell=True,
+)
 
 # make Hi-C data
-bins = pd.read_table('./test.10.bins', sep='\t')
+bins = pd.read_table("./test.10.bins", sep="\t")
 EIG_PERIOD_BP = 500
 EIG_AMPLITUDE = np.sqrt(0.5)
 SCALING = -2
 MAX_CIS_COUNTS = 1e8
 MAX_TRANS_COUNTS = 1e5
 
-bins['eig'] = EIG_AMPLITUDE * np.sin(bins.start * 2 * np.pi / EIG_PERIOD_BP)
-bins['key'] = 0
-pixels = pd.merge(bins, bins, on='key', how='outer', suffixes=('1', '2'))
-pixels.drop('key', axis='columns', inplace=True)
-pixels['count'] = np.nan
+bins["eig"] = EIG_AMPLITUDE * np.sin(bins.start * 2 * np.pi / EIG_PERIOD_BP)
+bins["key"] = 0
+pixels = pd.merge(bins, bins, on="key", how="outer", suffixes=("1", "2"))
+pixels.drop("key", axis="columns", inplace=True)
+pixels["count"] = np.nan
 
-cis = pixels.chrom1==pixels.chrom2
-pixels.loc[cis, 'count'] = pixels[cis].eval(
-    '@MAX_CIS_COUNTS * ((abs(start1-start2)+@BIN_SIZE)**@SCALING) * (1.0+eig1*eig2)')
-pixels.loc[~cis, 'count'] = pixels[~cis].eval(
-    '@MAX_TRANS_COUNTS * (1.0+eig1*eig2)')
+cis = pixels.chrom1 == pixels.chrom2
+pixels.loc[cis, "count"] = pixels[cis].eval(
+    "@MAX_CIS_COUNTS * ((abs(start1-start2)+@BIN_SIZE)**@SCALING) * (1.0+eig1*eig2)"
+)
+pixels.loc[~cis, "count"] = pixels[~cis].eval("@MAX_TRANS_COUNTS * (1.0+eig1*eig2)")
 
-pixels['count'] = pixels['count'].astype(int)
-pixels[['chrom1', 'start1', 'end1', 'chrom2', 'start2', 'end2', 'count']].to_csv(
-    './sin_eigs_mat.bg2.gz', sep='\t', index=False, header=None, compression='gzip')
+pixels["count"] = pixels["count"].astype(int)
+pixels[["chrom1", "start1", "end1", "chrom2", "start2", "end2", "count"]].to_csv(
+    "./sin_eigs_mat.bg2.gz", sep="\t", index=False, header=None, compression="gzip"
+)
 
 
 # make a cooler
 subprocess.check_output(
-    'cooler load -f bg2 --count-as-float --tril-action drop '
-    + f'./test.chrom.sizes:{BIN_SIZE} ./sin_eigs_mat.bg2.gz '
-    + './sin_eigs_mat.cool',
-    shell=True)
+    "cooler load -f bg2 --count-as-float --tril-action drop "
+    + f"./test.chrom.sizes:{BIN_SIZE} ./sin_eigs_mat.bg2.gz "
+    + "./sin_eigs_mat.cool",
+    shell=True,
+)
 
 # fake IC
-import h5py
-f=h5py.File('./sin_eigs_mat.cool')
-f['bins/weight'] = np.ones_like(f['bins/start'], dtype=float)
-f['bins/weight'].attrs['ignore_diags'] = 2
+f = h5py.File("./sin_eigs_mat.cool")
+f["bins/weight"] = np.ones_like(f["bins/start"], dtype=float)
+f["bins/weight"].attrs["ignore_diags"] = 2
 f.close()

--- a/tests/test_compartments_saddle.py
+++ b/tests/test_compartments_saddle.py
@@ -7,67 +7,70 @@ import pandas as pd
 
 
 def test_compartment_cli(request, tmpdir):
-    in_cool = op.join(request.fspath.dirname, 'data/sin_eigs_mat.cool')
-    out_eig_prefix = op.join(tmpdir, 'test.eigs')
+    in_cool = op.join(request.fspath.dirname, "data/sin_eigs_mat.cool")
+    out_eig_prefix = op.join(tmpdir, "test.eigs")
     try:
-        result = subprocess.check_output(
-            f'python -m cooltools call-compartments -o {out_eig_prefix} {in_cool}',
-            shell=True
-            ).decode('ascii')
+        subprocess.check_output(
+            f"python -m cooltools call-compartments -o {out_eig_prefix} {in_cool}",
+            shell=True,
+        ).decode("ascii")
     except subprocess.CalledProcessError as e:
         print(e.output)
         print(sys.exc_info())
         raise e
-    test_eigs = pd.read_table(out_eig_prefix+'.cis.vecs.tsv', sep='\t')
-    gb = test_eigs.groupby('chrom')
+    test_eigs = pd.read_table(out_eig_prefix + ".cis.vecs.tsv", sep="\t")
+    gb = test_eigs.groupby("chrom")
     for chrom in gb.groups:
         chrom_eigs = gb.get_group(chrom)
-        r = np.abs(np.corrcoef(chrom_eigs.E1.values,
-                               np.sin(chrom_eigs.start * 2 * np.pi / 500))[0,1])
-        assert r>0.95
+        r = np.abs(
+            np.corrcoef(
+                chrom_eigs.E1.values, np.sin(chrom_eigs.start * 2 * np.pi / 500)
+            )[0, 1]
+        )
+        assert r > 0.95
 
 
 def test_saddle_cli(request, tmpdir):
-    in_cool = op.join(request.fspath.dirname, 'data/sin_eigs_mat.cool')
-    out_eig_prefix = op.join(tmpdir, 'test.eigs')
-    out_expected = op.join(tmpdir, 'test.expected')
-    out_saddle_prefix = op.join(tmpdir, 'test.saddle')
+    in_cool = op.join(request.fspath.dirname, "data/sin_eigs_mat.cool")
+    out_eig_prefix = op.join(tmpdir, "test.eigs")
+    out_expected = op.join(tmpdir, "test.expected")
+    out_saddle_prefix = op.join(tmpdir, "test.saddle")
 
     try:
-        result = subprocess.check_output(
-            f'python -m cooltools call-compartments -o {out_eig_prefix} {in_cool}',
-            shell=True
-            ).decode('ascii')
+        subprocess.check_output(
+            f"python -m cooltools call-compartments -o {out_eig_prefix} {in_cool}",
+            shell=True,
+        ).decode("ascii")
     except subprocess.CalledProcessError as e:
         print(e.output)
         print(sys.exc_info())
         raise e
 
     try:
-        result = subprocess.check_output(
-            f'python -m cooltools compute-expected {in_cool} > {out_expected}',
-            shell=True
-            ).decode('ascii')
+        subprocess.check_output(
+            f"python -m cooltools compute-expected {in_cool} > {out_expected}",
+            shell=True,
+        ).decode("ascii")
     except subprocess.CalledProcessError as e:
         print(e.output)
         print(sys.exc_info())
         raise e
 
     try:
-        result = subprocess.check_output(
-            f'python -m cooltools compute-saddle -o {out_saddle_prefix} --range -0.5 0.5 '
-            +f'--n-bins 30 --scale log {in_cool} {out_eig_prefix}.cis.vecs.tsv {out_expected}',
-            shell=True
-        ).decode('ascii')
+        subprocess.check_output(
+            f"python -m cooltools compute-saddle -o {out_saddle_prefix} --range -0.5 0.5 "
+            + f"--n-bins 30 --scale log {in_cool} {out_eig_prefix}.cis.vecs.tsv {out_expected}",
+            shell=True,
+        ).decode("ascii")
     except subprocess.CalledProcessError as e:
         print(e.output)
         print(sys.exc_info())
         raise e
 
-    log2_sad = np.log2(np.load(out_saddle_prefix + '.saddledump.npz')['saddledata'])
-    bins = np.load(out_saddle_prefix + '.saddledump.npz')['binedges']
+    log2_sad = np.log2(np.load(out_saddle_prefix + ".saddledump.npz")["saddledata"])
+    bins = np.load(out_saddle_prefix + ".saddledump.npz")["binedges"]
     binmids = (bins[:-1] + bins[1:]) / 2
-    log2_theor_sad = np.log2(1 + binmids[None,:] * binmids[:,None])
+    log2_theor_sad = np.log2(1 + binmids[None, :] * binmids[:, None])
 
     log2_sad_flat = log2_sad[1:-1, 1:-1].flatten()
     log2_theor_sad_flat = log2_theor_sad.flatten()

--- a/tests/test_dotfinder_chunking.py
+++ b/tests/test_dotfinder_chunking.py
@@ -13,173 +13,177 @@ from cooltools.lib.numutils import LazyToeplitz
 testdir = op.realpath(op.dirname(__file__))
 
 # mock input data location:
-mock_input = op.join(testdir, 'data', 'mock_inputs.npz')
-mock_result = op.join(testdir, 'data', 'mock_res.csv.gz')
+mock_input = op.join(testdir, "data", "mock_inputs.npz")
+mock_result = op.join(testdir, "data", "mock_res.csv.gz")
 
 
 # load bunch of array from a numpy npz container:
 arrays_loaded = np.load(mock_input)
-# snippets of M_raw, M_ice, E_ice and v_ice are supposed 
+# snippets of M_raw, M_ice, E_ice and v_ice are supposed
 # to be there ...
-mock_M_raw = arrays_loaded['mock_M_raw']
-mock_M_ice = arrays_loaded['mock_M_ice']
-mock_E_ice = arrays_loaded['mock_E_ice']
-mock_v_ice = arrays_loaded['mock_v_ice']
+mock_M_raw = arrays_loaded["mock_M_raw"]
+mock_M_ice = arrays_loaded["mock_M_ice"]
+mock_E_ice = arrays_loaded["mock_E_ice"]
+mock_v_ice = arrays_loaded["mock_v_ice"]
 
 # 1D expected extracted for tiling-tests:
-mock_exp = LazyToeplitz(mock_E_ice[0,:])
+mock_exp = LazyToeplitz(mock_E_ice[0, :])
 
 # we need w-edge for tiling procedures:
 w = 3
 # p = 1
 # kernel type: 'donut'
 # # just a simple donut kernel for testing:
-kernel = np.array([[1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 0, 0, 0, 1, 1],
-                   [0, 0, 0, 0, 0, 0, 0],
-                   [1, 1, 0, 0, 0, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1]])
+kernel = np.array(
+    [
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 0, 0, 0, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+    ]
+)
 # bin size:
 # mock data were extracted
 # from 20kb matrix:
-b=20000
+b = 20000
 # 2MB aroud diagonal to look at:
-band=2e+6
+band = 2e6
 # 1MB aroud diagonal to look at:
-band_1=1e+6
+band_1 = 1e6
 
 # start, stop for tiling procedures:
 start, stop = 0, len(mock_M_raw)
 
 # load mock results:
 mock_res = pd.read_csv(mock_result)
-mock_res = mock_res.rename(columns={'row':'bin1_id','col':'bin2_id'})
+mock_res = mock_res.rename(columns={"row": "bin1_id", "col": "bin2_id"})
 
 
 def test_adjusted_expected_tile_some_nans_and_diag_tiling():
     print("Running tile some nans la_exp test + diag tiling")
     # first, generate that locally-adjusted expected:
     nnans = 1
-    band_1_idx = int(band_1/b)
+    band_1_idx = int(band_1 / b)
     res_df = pd.DataFrame([])
-    for tile in dotfinder.diagonal_matrix_tiling(start, stop, bandwidth=band_1_idx, edge=w):
+    for tile in dotfinder.diagonal_matrix_tiling(
+        start, stop, bandwidth=band_1_idx, edge=w
+    ):
         # let's keep i,j-part explicit here:
         tilei, tilej = tile, tile
         # define origin:
         origin = (tilei[0], tilej[0])
         # RAW observed matrix slice:
-        observed = mock_M_raw[slice(*tilei),slice(*tilej)]
+        observed = mock_M_raw[slice(*tilei), slice(*tilej)]
         # trying new expected function:
-        expected = mock_exp[slice(*tilei),slice(*tilej)]
+        expected = mock_exp[slice(*tilei), slice(*tilej)]
         # for diagonal chuynking/tiling tilei==tilej:
         ice_weight = mock_v_ice[slice(*tilei)]
         # that's the main working function from dotfinder:
-        res = dotfinder.get_adjusted_expected_tile_some_nans(origin = origin,
-                                                 observed = observed,
-                                                 expected = expected,
-                                                 bal_weights = ice_weight,
-                                                 kernels = {"donut":kernel,
-                                                         "footprint":np.ones_like(kernel)} )
-        is_inside_band = (res["bin1_id"] > (res["bin2_id"]-band_1_idx))
+        res = dotfinder.get_adjusted_expected_tile_some_nans(
+            origin=origin,
+            observed=observed,
+            expected=expected,
+            bal_weights=ice_weight,
+            kernels={"donut": kernel, "footprint": np.ones_like(kernel)},
+        )
+        is_inside_band = res["bin1_id"] > (res["bin2_id"] - band_1_idx)
         # new style, selecting good guys:
-        does_comply_nans = (res["la_exp."+"footprint"+".nnans"] < nnans)
+        does_comply_nans = res["la_exp." + "footprint" + ".nnans"] < nnans
         # so, selecting inside band and nNaNs compliant results and append:
         res_df = res_df.append(
-                            res[is_inside_band & does_comply_nans],
-                            ignore_index=True)
-
+            res[is_inside_band & does_comply_nans], ignore_index=True
+        )
 
     # drop dups (from overlaping tiles), sort and reset index:
-    res_df = res_df \
-                .drop_duplicates() \
-                .sort_values(by=['bin1_id','bin2_id']) \
-                .reset_index(drop=True)
+    res_df = (
+        res_df.drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
+    )
 
     # prepare mock_data for comparison:
     # get a subset of mock results (inside 1Mb band):
-    is_inside_band_1 = (mock_res["bin1_id"]>(mock_res["bin2_id"]-band_1_idx))
+    is_inside_band_1 = mock_res["bin1_id"] > (mock_res["bin2_id"] - band_1_idx)
     mock_res_1 = mock_res[is_inside_band_1].reset_index(drop=True)
     # apparently sorting is needed in this case:
-    mock_res_1 = mock_res_1.sort_values(by=['bin1_id','bin2_id']).reset_index(drop=True)
-
+    mock_res_1 = mock_res_1.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
+        drop=True
+    )
 
     # ACTUAL TESTS:
     # integer part of DataFrame must equals exactly:
-    assert (
-        res_df[['bin1_id','bin2_id']].equals(
-            mock_res_1[['bin1_id','bin2_id']])
-        )
+    assert res_df[["bin1_id", "bin2_id"]].equals(mock_res_1[["bin1_id", "bin2_id"]])
     # compare floating point part separately:
-    assert (
-        np.isclose(
-            res_df["la_exp."+"donut"+".value"],
-            mock_res_1['la_expected'],
-            equal_nan=True).all()
-        )
-
-
+    assert np.isclose(
+        res_df["la_exp." + "donut" + ".value"],
+        mock_res_1["la_expected"],
+        equal_nan=True,
+    ).all()
 
 
 def test_adjusted_expected_tile_some_nans_and_square_tiling():
     print("Running tile some nans la_exp test + square tiling")
     # first, generate that locally-adjusted expected:
     nnans = 1
-    band_idx = int(band/b)
+    band_idx = int(band / b)
     res_df = pd.DataFrame([])
-    for tilei, tilej in dotfinder.square_matrix_tiling(start, stop, step=40, edge=w, square=False):
+    for tilei, tilej in dotfinder.square_matrix_tiling(
+        start, stop, step=40, edge=w, square=False
+    ):
         # define origin:
         origin = (tilei[0], tilej[0])
         # RAW observed matrix slice:
-        observed = mock_M_raw[slice(*tilei),slice(*tilej)]
+        observed = mock_M_raw[slice(*tilei), slice(*tilej)]
         # trying new expected function:
-        expected = mock_exp[slice(*tilei),slice(*tilej)]
+        expected = mock_exp[slice(*tilei), slice(*tilej)]
         # for diagonal chuynking/tiling tilei==tilej:
         ice_weight_i = mock_v_ice[slice(*tilei)]
         ice_weight_j = mock_v_ice[slice(*tilej)]
         # that's the main working function from dotfinder:
-        res = dotfinder.get_adjusted_expected_tile_some_nans(origin = origin,
-                                                 observed = observed,
-                                                 expected = expected,
-                                                 bal_weights = (ice_weight_i, ice_weight_j),
-                                                 kernels = {"donut":kernel,
-                                                         "footprint":np.ones_like(kernel)},
-                                                 # nan_threshold=1,
-                                                 verbose=False)
-        is_inside_band = (res["bin1_id"] > (res["bin2_id"]-band_idx))
+        res = dotfinder.get_adjusted_expected_tile_some_nans(
+            origin=origin,
+            observed=observed,
+            expected=expected,
+            bal_weights=(ice_weight_i, ice_weight_j),
+            kernels={"donut": kernel, "footprint": np.ones_like(kernel)},
+            # nan_threshold=1,
+            verbose=False,
+        )
+        is_inside_band = res["bin1_id"] > (res["bin2_id"] - band_idx)
         # new style, selecting good guys:
-        does_comply_nans = (res["la_exp."+"footprint"+".nnans"] < nnans)
+        does_comply_nans = res["la_exp." + "footprint" + ".nnans"] < nnans
         # so, select inside band and nNaNs compliant results and append:
         res_df = res_df.append(
-                            res[is_inside_band & does_comply_nans],
-                            ignore_index=True)
+            res[is_inside_band & does_comply_nans], ignore_index=True
+        )
 
     # drop dups (from overlaping tiles), sort and reset index:
-    res_df = res_df \
-                .drop_duplicates() \
-                .sort_values(by=['bin1_id','bin2_id']) \
-                .reset_index(drop=True)
+    res_df = (
+        res_df.drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
+    )
 
     # prepare mock_data for comparison:
     # apparently sorting is needed in this case:
-    mock_res_sorted = mock_res.sort_values(by=['bin1_id','bin2_id']).reset_index(drop=True)
+    mock_res_sorted = mock_res.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
+        drop=True
+    )
 
     # ACTUAL TESTS:
     # integer part of DataFrame must equals exactly:
-    assert (
-        res_df[['bin1_id','bin2_id']].equals(
-            mock_res_sorted[['bin1_id','bin2_id']])
-        )
+    assert res_df[["bin1_id", "bin2_id"]].equals(
+        mock_res_sorted[["bin1_id", "bin2_id"]]
+    )
     # compare floating point part separately:
-    assert (
-        np.isclose(
-            res_df["la_exp."+"donut"+".value"],
-            mock_res_sorted['la_expected'],
-            equal_nan=True).all()
-        )
-
-
+    assert np.isclose(
+        res_df["la_exp." + "donut" + ".value"],
+        mock_res_sorted["la_expected"],
+        equal_nan=True,
+    ).all()
 
 
 def test_adjusted_expected_tile_some_nans_and_square_tiling_diag_band():
@@ -189,7 +193,7 @@ def test_adjusted_expected_tile_some_nans_and_square_tiling_diag_band():
     #     for chrom in chroms:
     #         chr_start, chr_stop = the_c.extent(chrom)
     #         for tilei, tilej in square_matrix_tiling(chr_start, chr_stop, step, w):
-    #             # check if a given tile intersects with 
+    #             # check if a given tile intersects with
     #             # with the diagonal band of interest ...
     #             diag_from = tilej[0] - tilei[1]
     #             diag_to   = tilej[1] - tilei[0]
@@ -202,73 +206,65 @@ def test_adjusted_expected_tile_some_nans_and_square_tiling_diag_band():
     #                 yield chrom, tilei, tilej
     # first, generate that locally-adjusted expected:
     nnans = 1
-    band_idx = int(band/b)
+    band_idx = int(band / b)
     res_df = pd.DataFrame([])
-    for tilei, tilej in dotfinder.square_matrix_tiling(start, stop, step=40, edge=w, square=False):
-        # check if a given tile intersects with 
+    for tilei, tilej in dotfinder.square_matrix_tiling(
+        start, stop, step=40, edge=w, square=False
+    ):
+        # check if a given tile intersects with
         # with the diagonal band of interest ...
         diag_from = tilej[0] - tilei[1]
-        diag_to   = tilej[1] - tilei[0]
+        diag_to = tilej[1] - tilei[0]
         #
         band_from = 0
-        band_to   = band_idx
+        band_to = band_idx
         # we are using this >2w trick to exclude
         # tiles from the lower triangle from calculations ...
-        if (min(band_to,diag_to) - max(band_from,diag_from)) > 2*w:
+        if (min(band_to, diag_to) - max(band_from, diag_from)) > 2 * w:
             # define origin:
             origin = (tilei[0], tilej[0])
             # RAW observed matrix slice:
-            observed = mock_M_raw[slice(*tilei),slice(*tilej)]
+            observed = mock_M_raw[slice(*tilei), slice(*tilej)]
             # trying new expected function:
-            expected = mock_exp[slice(*tilei),slice(*tilej)]
+            expected = mock_exp[slice(*tilei), slice(*tilej)]
             # for diagonal chuynking/tiling tilei==tilej:
             ice_weight_i = mock_v_ice[slice(*tilei)]
             ice_weight_j = mock_v_ice[slice(*tilej)]
             # that's the main working function from dotfinder:
-            res = dotfinder.get_adjusted_expected_tile_some_nans(origin = origin,
-                                                     observed = observed,
-                                                     expected = expected,
-                                                     bal_weights = (ice_weight_i, ice_weight_j),
-                                                     kernels = {"donut":kernel,
-                                                             "footprint":np.ones_like(kernel)},
-                                                     # nan_threshold=1,
-                                                     verbose=False)
-            is_inside_band = (res["bin1_id"] > (res["bin2_id"]-band_idx))
+            res = dotfinder.get_adjusted_expected_tile_some_nans(
+                origin=origin,
+                observed=observed,
+                expected=expected,
+                bal_weights=(ice_weight_i, ice_weight_j),
+                kernels={"donut": kernel, "footprint": np.ones_like(kernel)},
+                # nan_threshold=1,
+                verbose=False,
+            )
+            is_inside_band = res["bin1_id"] > (res["bin2_id"] - band_idx)
             # new style, selecting good guys:
-            does_comply_nans = (res["la_exp."+"footprint"+".nnans"] < nnans)
+            does_comply_nans = res["la_exp." + "footprint" + ".nnans"] < nnans
             # so, select inside band and nNaNs compliant results and append:
             res_df = res_df.append(
-                                res[is_inside_band & does_comply_nans],
-                                ignore_index=True)
+                res[is_inside_band & does_comply_nans], ignore_index=True
+            )
 
     # sort and reset index, there shouldn't be any duplicates now:
-    res_df = res_df \
-                .sort_values(by=['bin1_id','bin2_id']) \
-                .reset_index(drop=True)
+    res_df = res_df.sort_values(by=["bin1_id", "bin2_id"]).reset_index(drop=True)
 
     # prepare mock_data for comparison:
     # apparently sorting is needed in this case:
-    mock_res_sorted = mock_res.sort_values(by=['bin1_id','bin2_id']).reset_index(drop=True)
+    mock_res_sorted = mock_res.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
+        drop=True
+    )
 
     # ACTUAL TESTS:
     # integer part of DataFrame must equals exactly:
-    assert (
-        res_df[['bin1_id','bin2_id']].equals(
-            mock_res_sorted[['bin1_id','bin2_id']])
-        )
+    assert res_df[["bin1_id", "bin2_id"]].equals(
+        mock_res_sorted[["bin1_id", "bin2_id"]]
+    )
     # compare floating point part separately:
-    assert (
-        np.isclose(
-            res_df["la_exp."+"donut"+".value"],
-            mock_res_sorted['la_expected'],
-            equal_nan=True).all()
-        )
-
-
-
-
-
-
-
-
-
+    assert np.isclose(
+        res_df["la_exp." + "donut" + ".value"],
+        mock_res_sorted["la_expected"],
+        equal_nan=True,
+    ).all()

--- a/tests/test_dotfinder_chunking.py
+++ b/tests/test_dotfinder_chunking.py
@@ -58,8 +58,10 @@ band_1 = 1e6
 start, stop = 0, len(mock_M_raw)
 
 # load mock results:
-mock_res = pd.read_csv(mock_result)
-mock_res = mock_res.rename(columns={"row": "bin1_id", "col": "bin2_id"})
+mock_res = (
+    pd.read_csv(mock_result)
+    .rename(columns={"row": "bin1_id", "col": "bin2_id"})
+)
 
 
 def test_adjusted_expected_tile_some_nans_and_diag_tiling():
@@ -99,7 +101,8 @@ def test_adjusted_expected_tile_some_nans_and_diag_tiling():
 
     # drop dups (from overlaping tiles), sort and reset index:
     res_df = (
-        res_df.drop_duplicates()
+        res_df
+        .drop_duplicates()
         .sort_values(by=["bin1_id", "bin2_id"])
         .reset_index(drop=True)
     )
@@ -109,8 +112,11 @@ def test_adjusted_expected_tile_some_nans_and_diag_tiling():
     is_inside_band_1 = mock_res["bin1_id"] > (mock_res["bin2_id"] - band_1_idx)
     mock_res_1 = mock_res[is_inside_band_1].reset_index(drop=True)
     # apparently sorting is needed in this case:
-    mock_res_1 = mock_res_1.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
-        drop=True
+    mock_res_1 = (
+        mock_res_1
+        .drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
     )
 
     # ACTUAL TESTS:
@@ -162,15 +168,19 @@ def test_adjusted_expected_tile_some_nans_and_square_tiling():
 
     # drop dups (from overlaping tiles), sort and reset index:
     res_df = (
-        res_df.drop_duplicates()
+        res_df
+        .drop_duplicates()
         .sort_values(by=["bin1_id", "bin2_id"])
         .reset_index(drop=True)
     )
 
     # prepare mock_data for comparison:
     # apparently sorting is needed in this case:
-    mock_res_sorted = mock_res.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
-        drop=True
+    mock_res_sorted = (
+        mock_res
+        .drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
     )
 
     # ACTUAL TESTS:
@@ -249,12 +259,20 @@ def test_adjusted_expected_tile_some_nans_and_square_tiling_diag_band():
             )
 
     # sort and reset index, there shouldn't be any duplicates now:
-    res_df = res_df.sort_values(by=["bin1_id", "bin2_id"]).reset_index(drop=True)
+    res_df = (
+        res_df
+        .drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
+    )
 
     # prepare mock_data for comparison:
     # apparently sorting is needed in this case:
-    mock_res_sorted = mock_res.sort_values(by=["bin1_id", "bin2_id"]).reset_index(
-        drop=True
+    mock_res_sorted = (
+        mock_res
+        .drop_duplicates()
+        .sort_values(by=["bin1_id", "bin2_id"])
+        .reset_index(drop=True)
     )
 
     # ACTUAL TESTS:

--- a/tests/test_dotfinder_la_exp.py
+++ b/tests/test_dotfinder_la_exp.py
@@ -14,21 +14,21 @@ from cooltools.dotfinder import get_adjusted_expected_tile_some_nans
 testdir = op.realpath(op.dirname(__file__))
 
 # mock input data location:
-mock_input = op.join(testdir, 'data', 'mock_inputs.npz')
-mock_result = op.join(testdir, 'data', 'mock_res.csv.gz')
+mock_input = op.join(testdir, "data", "mock_inputs.npz")
+mock_result = op.join(testdir, "data", "mock_res.csv.gz")
 
 # load mock results:
 mock_res = pd.read_csv(mock_result)
-mock_res = mock_res.rename(columns={'row':'bin1_id','col':'bin2_id'})
+mock_res = mock_res.rename(columns={"row": "bin1_id", "col": "bin2_id"})
 
 # load bunch of array from a numpy npz container:
 arrays_loaded = np.load(mock_input)
-# snippets of M_raw, M_ice, E_ice and v_ice are supposed 
+# snippets of M_raw, M_ice, E_ice and v_ice are supposed
 # to be there ...
-mock_M_raw = arrays_loaded['mock_M_raw']
-mock_M_ice = arrays_loaded['mock_M_ice']
-mock_E_ice = arrays_loaded['mock_E_ice']
-mock_v_ice = arrays_loaded['mock_v_ice']
+mock_M_raw = arrays_loaded["mock_M_raw"]
+mock_M_ice = arrays_loaded["mock_M_ice"]
+mock_E_ice = arrays_loaded["mock_E_ice"]
+mock_v_ice = arrays_loaded["mock_v_ice"]
 
 
 # we need w-edge for tiling procedures:
@@ -36,19 +36,23 @@ mock_v_ice = arrays_loaded['mock_v_ice']
 # p = 1
 # kernel type: 'donut'
 # # just a simple donut kernel for testing:
-kernel = np.array([[1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 0, 0, 0, 1, 1],
-                   [0, 0, 0, 0, 0, 0, 0],
-                   [1, 1, 0, 0, 0, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1],
-                   [1, 1, 1, 0, 1, 1, 1]])
+kernel = np.array(
+    [
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 0, 0, 0, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+        [1, 1, 1, 0, 1, 1, 1],
+    ]
+)
 # bin size:
 # mock data were extracted
 # from 20kb matrix:
-b=20000
+b = 20000
 # 2MB aroud diagonal to look at:
-band=2e+6
+band = 2e6
 
 
 #################################################################
@@ -57,64 +61,53 @@ band=2e+6
 def test_adjusted_expected_tile_some_nans():
     print("Running tile some nans la_exp test")
     # first, generate that locally-adjusted expected:
-    # Ed_raw, mask_ndx, Cobs, Cexp, NN = 
+    # Ed_raw, mask_ndx, Cobs, Cexp, NN =
     res = get_adjusted_expected_tile_some_nans(
-                         origin=(0,0),
-                         observed=mock_M_raw, # should be RAW ...
-                         expected=mock_E_ice,
-                         bal_weights=mock_v_ice,
-                         kernels={"donut":kernel,
-                                 "footprint":np.ones_like(kernel)})
+        origin=(0, 0),
+        observed=mock_M_raw,  # should be RAW ...
+        expected=mock_E_ice,
+        bal_weights=mock_v_ice,
+        kernels={"donut": kernel, "footprint": np.ones_like(kernel)},
+    )
     # mock results are supposedly for
     # the contacts closer than the band
     # nucleotides to each other...
-    # we want to retire that functional 
+    # we want to retire that functional
     # from the 'get_adjusted_expected_tile_some_nans'
     # so we should complement that selection
     # here:
-    nnans = 1 # no nans tolerated
-    band_idx = int(band/b)
-    is_inside_band   = (res["bin1_id"]>(res["bin2_id"]-band_idx))
-    does_comply_nans = (res["la_exp."+"footprint"+".nnans"] < nnans)
+    nnans = 1  # no nans tolerated
+    band_idx = int(band / b)
+    is_inside_band = res["bin1_id"] > (res["bin2_id"] - band_idx)
+    does_comply_nans = res["la_exp." + "footprint" + ".nnans"] < nnans
     # so, selecting inside band and nNaNs compliant results:
     res = res[is_inside_band & does_comply_nans].reset_index(drop=True)
-    # 
+    #
     # ACTUAL TESTS:
     # integer part of DataFrame must equals exactly:
-    assert (
-        res[['bin1_id','bin2_id']].equals(
-            mock_res[['bin1_id','bin2_id']])
-        )
+    assert res[["bin1_id", "bin2_id"]].equals(mock_res[["bin1_id", "bin2_id"]])
     # compare floating point part separately:
-    assert (
-        np.isclose(
-            res["la_exp."+"donut"+".value"],
-            mock_res['la_expected'],
-            equal_nan=True).all()
-        )
+    assert np.isclose(
+        res["la_exp." + "donut" + ".value"], mock_res["la_expected"], equal_nan=True
+    ).all()
     #
     # try recovering more NaNs ...
     # (allowing 1 here per pixel's footprint)...
     res = get_adjusted_expected_tile_some_nans(
-                     origin=(0,0),
-                     observed=mock_M_raw, # should be RAW...
-                     expected=mock_E_ice,
-                     bal_weights=mock_v_ice,
-                     kernels={"donut":kernel,
-                             "footprint":np.ones_like(kernel)})
+        origin=(0, 0),
+        observed=mock_M_raw,  # should be RAW...
+        expected=mock_E_ice,
+        bal_weights=mock_v_ice,
+        kernels={"donut": kernel, "footprint": np.ones_like(kernel)},
+    )
     # post-factum filtering resides
     # outside of get_la_exp now:
-    nnans = 2 # just 1 nan tolerated
-    band_idx = int(band/b)
-    is_inside_band = (res["bin1_id"]>(res["bin2_id"]-band_idx))
-    does_comply_nans = (res["la_exp."+"footprint"+".nnans"] < nnans)
+    nnans = 2  # just 1 nan tolerated
+    band_idx = int(band / b)
+    is_inside_band = res["bin1_id"] > (res["bin2_id"] - band_idx)
+    does_comply_nans = res["la_exp." + "footprint" + ".nnans"] < nnans
     # so, selecting inside band and comply nNaNs results only:
     res = res[is_inside_band & does_comply_nans].reset_index(drop=True)
 
     # now we can only guess the size:
-    assert (len(res) > len(mock_res))
-
-
-
-
-
+    assert len(res) > len(mock_res)

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -1,41 +1,42 @@
 import os.path as op
-import numpy as np
 import pandas as pd
 
 import bioframe
 import cooler
 import cooltools.expected
 
-chromsizes = bioframe.fetch_chromsizes('mm9')
+chromsizes = bioframe.fetch_chromsizes("mm9")
 chromosomes = list(chromsizes.index)
 supports = [(chrom, 0, chromsizes[chrom]) for chrom in chromosomes]
 
 
 def test_diagsum(request):
-    clr = cooler.Cooler(op.join(request.fspath.dirname, 'data/CN.mm9.1000kb.cool'))
+    clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
     tables = cooltools.expected.diagsum(
-            clr, 
-            supports, 
-            transforms={
-                'balanced': lambda p: p['count'] * p['weight1'] * p['weight2']
-            },
-            chunksize=10000000)
-    exc = pd.concat(
-        [tables[support] for support in supports], 
-        keys=[support[0] for support in supports], 
-        names=['chrom'])
+        clr,
+        supports,
+        transforms={"balanced": lambda p: p["count"] * p["weight1"] * p["weight2"]},
+        chunksize=10000000,
+    )
+    pd.concat(
+        [tables[support] for support in supports],
+        keys=[support[0] for support in supports],
+        names=["chrom"],
+    )
 
 
 def test_blocksum(request):
-    clr = cooler.Cooler(op.join(request.fspath.dirname, 'data/CN.mm9.1000kb.cool'))
+    clr = cooler.Cooler(op.join(request.fspath.dirname, "data/CN.mm9.1000kb.cool"))
     records = cooltools.expected.blocksum_pairwise(
         clr,
-        supports, 
-        transforms={
-            'balanced': lambda p: p['count'] * p['weight1'] * p['weight2'],
-        },
-        chunksize=10000000)
-    ext = pd.DataFrame(
-        [{'chrom1': s1[0], 'chrom2': s2[0], **rec} 
-            for (s1, s2), rec in records.items()], 
-        columns=['chrom1', 'chrom2', 'n_valid', 'count.sum', 'balanced.sum'])
+        supports,
+        transforms={"balanced": lambda p: p["count"] * p["weight1"] * p["weight2"]},
+        chunksize=10000000,
+    )
+    pd.DataFrame(
+        [
+            {"chrom1": s1[0], "chrom2": s2[0], **rec}
+            for (s1, s2), rec in records.items()
+        ],
+        columns=["chrom1", "chrom2", "n_valid", "count.sum", "balanced.sum"],
+    )

--- a/tests/test_lazy_toeplitz.py
+++ b/tests/test_lazy_toeplitz.py
@@ -5,8 +5,8 @@ from cooltools.lib.numutils import LazyToeplitz
 
 n = 100
 m = 150
-c = np.arange(1, n+1)
-r = np.r_[1,np.arange(-2, -m, -1)]
+c = np.arange(1, n + 1)
+r = np.r_[1, np.arange(-2, -m, -1)]
 
 L = LazyToeplitz(c, r)
 T = toeplitz(c, r)
@@ -14,56 +14,56 @@ T = toeplitz(c, r)
 
 def test_symmetric():
     for si in [
-            slice(10, 20), 
-            slice(0, 150),
-            slice(0, 0),
-            slice(150, 150),
-            slice(10, 10)
-        ]:
+        slice(10, 20),
+        slice(0, 150),
+        slice(0, 0),
+        slice(150, 150),
+        slice(10, 10),
+    ]:
         assert np.allclose(L[si, si], T[si, si])
 
 
 def test_triu_no_overlap():
     for si, sj in [
-            (slice(10, 20), slice(30, 40)),
-            (slice(10, 15), slice(30, 40)),
-            (slice(10, 20), slice(30, 45)),
-        ]:
+        (slice(10, 20), slice(30, 40)),
+        (slice(10, 15), slice(30, 40)),
+        (slice(10, 20), slice(30, 45)),
+    ]:
         assert np.allclose(L[si, sj], T[si, sj])
 
 
 def test_tril_no_overlap():
     for si, sj in [
-            (slice(30, 40), slice(10, 20)),
-            (slice(30, 40), slice(10, 15)),
-            (slice(30, 45), slice(10, 20)),
-        ]:
+        (slice(30, 40), slice(10, 20)),
+        (slice(30, 40), slice(10, 15)),
+        (slice(30, 45), slice(10, 20)),
+    ]:
         assert np.allclose(L[si, sj], T[si, sj])
 
 
 def test_triu_with_overlap():
     for si, sj in [
-            (slice(10, 20), slice(15, 25)),
-            (slice(13, 22), slice(15, 25)),
-            (slice(10, 20), slice(18, 22)),
-        ]:
+        (slice(10, 20), slice(15, 25)),
+        (slice(13, 22), slice(15, 25)),
+        (slice(10, 20), slice(18, 22)),
+    ]:
         assert np.allclose(L[si, sj], T[si, sj])
 
 
 def test_tril_with_overlap():
     for si, sj in [
-            (slice(15, 25), slice(10, 20)),
-            (slice(15, 22), slice(10, 20)),
-            (slice(15, 25), slice(10, 18)),
-        ]:
+        (slice(15, 25), slice(10, 20)),
+        (slice(15, 22), slice(10, 20)),
+        (slice(15, 25), slice(10, 18)),
+    ]:
         assert np.allclose(L[si, sj], T[si, sj])
 
 
 def test_nested():
     for si, sj in [
-            (slice(10, 40), slice(20, 30)),
-            (slice(10, 35), slice(20, 30)),
-            (slice(10, 40), slice(20, 25)),
-            (slice(20, 30), slice(10, 40)),
-        ]:
+        (slice(10, 40), slice(20, 30)),
+        (slice(10, 35), slice(20, 30)),
+        (slice(10, 40), slice(20, 25)),
+        (slice(20, 30), slice(10, 40)),
+    ]:
         assert np.allclose(L[si, sj], T[si, sj])


### PR DESCRIPTION
Applied [black](https://github.com/psf/black) to codebase to make everything pep8-compliant.

Added config files for:
* [flake8](http://flake8.pycqa.org/en/latest/) `.flake8`
* [coverage](https://coverage.readthedocs.io/en/v4.5.x/) `.coveragerc`
* pytest  `pytest.ini` (to run [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) and [pytest-flake8](https://github.com/tholo/pytest-flake8) plugins)

The pytest plugins will run locally and in CI and will complain when code checked in isn't pep8. 
