### PR TITLE
Update dotfinder.py

### DIFF
--- a/cooltools/dotfinder.py
+++ b/cooltools/dotfinder.py
@@ -1773,7 +1773,7 @@ def clustering_step(
 
     # report only centroids with highest Observed:
     chrom_clust_group = df.groupby(["chrom1", "chrom2", "c_label"])
-    centroids = df.loc[chrom_clust_group[obs_raw_name].idxmax()]
+    centroids = df.loc[df.index.intersection(chrom_clust_group[obs_raw_name].idxmax())]
     return centroids
 
 

--- a/cooltools/dotfinder.py
+++ b/cooltools/dotfinder.py
@@ -1770,10 +1770,12 @@ def clustering_step(
     df = pd.merge(
         scores_df, pixel_clust_df, how="left", left_index=True, right_index=True
     )
-
+    #prevents scores_df categorical values (all chroms, including chrM)
+    df['chrom1'] = df['chrom1'].astype(str)
+    df['chrom2'] = df['chrom2'].astype(str)
     # report only centroids with highest Observed:
     chrom_clust_group = df.groupby(["chrom1", "chrom2", "c_label"])
-    centroids = df.loc[df.index.intersection(chrom_clust_group[obs_raw_name].idxmax())]
+    centroids = df.loc[chrom_clust_group[obs_raw_name].idxmax()]
     return centroids
 
 


### PR DESCRIPTION
Note sure if this is the most efficient solution but it solved the int to float issue for chrom positions
@sergpolly @nvictus 

Warning:
/home/spracklin/devel/cooltools/cooltools/dotfinder.py:1776: FutureWarning: 
Passing list-likes to .loc or [] with any missing label will raise
KeyError in the future, you can use .reindex() as an alternative.

Solution found in:
https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike