### PR TITLE
Set default zoom order to 1

### DIFF
--- a/cooltools/lib/numutils.py
+++ b/cooltools/lib/numutils.py
@@ -1099,7 +1099,7 @@ def zoom_array(
     in_array,
     final_shape,
     same_sum=False,
-    zoom_function=partial(zoom, order=3),
+    zoom_function=partial(zoom, order=1),
     **zoom_kwargs
 ):
     """Rescale an array or image.


### PR DESCRIPTION
Somehow default zoom order was set to 3 instead of a much better default of 1! Goes against the docstring too.