### PR TITLE
Expected refactoring

### DIFF
--- a/cooltools/expected.py
+++ b/cooltools/expected.py
@@ -689,11 +689,11 @@ def _diagsum_symm(clr, fields, transforms, regions, span):
     pixels = clr.pixels()[lo:hi]
     pixels = cooler.annotate(pixels, bins, replace=False)
 
-    pixels["region1"] = assign_supports(pixels, regions, suffix="1")
-    pixels["regiont2"] = assign_supports(pixels, regions, suffix="2")
+    pixels["region1"] = assign_supports(pixels['bin1_id'], regions)
+    pixels["region2"] = assign_supports(pixels['bin2_id'], regions)
     pixels = pixels[pixels["region1"] == pixels["region2"]].copy()
 
-    pixels["diag"] = pixels["bin2_id"] - pixels["bin1_id"]
+    pixels["dist"] = pixels["bin2_id"] - pixels["bin1_id"]
     for field, t in transforms.items():
         pixels[field] = t(pixels)
 
@@ -714,16 +714,16 @@ def _diagsum_asymm(clr, fields, transforms, contact_type, regions1, regions2, sp
     elif contact_type == "trans":
         pixels = pixels[pixels["chrom1"] != pixels["chrom2"]].copy()
 
-    pixels["diag"] = pixels["bin2_id"] - pixels["bin1_id"]
+    pixels["dist"] = pixels["bin2_id"] - pixels["bin1_id"]
     for field, t in transforms.items():
         pixels[field] = t(pixels)
 
-    pixels["region1"] = assign_supports(pixels, regions1, suffix="1")
-    pixels["region2"] = assign_supports(pixels, regions2, suffix="2")
+    pixels["region1"] = assign_supports(pixels['bin1_id'], regions1)
+    pixels["region2"] = assign_supports(pixels['bin2_id'], regions2)
 
     pixel_groups = dict(iter(pixels.groupby(["region1", "region2"])))
     return {
-        (int(i), int(j)): group.groupby("diag")[fields].sum()
+        (int(i), int(j)): group.groupby("dist")[fields].sum()
         for (i, j), group in pixel_groups.items()
     }
 

--- a/cooltools/lib/common.py
+++ b/cooltools/lib/common.py
@@ -49,3 +49,21 @@ def assign_supports(features, supports, labels=False, suffix=""):
         supp_col = supp_col.map(lambda i: supports[int(i)], na_action="ignore")
 
     return supp_col
+
+
+
+def assign_regions_to_bins(bin_ids, regions_span):
+
+    regions_binsorted = (regions_span[(regions_span['bin_start']>=0) 
+                                      &(regions_span['bin_end']>=0) ]
+                            .sort_values(['bin_start', 'bin_end'])
+                            .reset_index())
+
+    bin_reg_idx_lo = regions_span['bin_start'].searchsorted(bin_ids,'right')-1
+    bin_reg_idx_hi = regions_span['bin_end'].searchsorted(bin_ids,'right')
+    mask_assigned = (bin_reg_idx_lo == bin_reg_idx_hi) & (bin_reg_idx_lo>=0)
+    
+    region_ids = pd.array([pd.NA]*len(bin_ids))
+    region_ids[mask_assigned] = regions_span['name'][bin_reg_idx_lo[mask_assigned]]
+    
+    return region_ids

--- a/cooltools/saddle.py
+++ b/cooltools/saddle.py
@@ -105,7 +105,7 @@ def digitize_track(binedges, track, regions=None):
         regions = [bioframe.parse_region(reg) for reg in regions]
         grouped = track.groupby("chrom")
         track = pd.concat(
-            bioframe.bedslice(grouped, chrom, st, end) for (chrom, st, end) in regions
+            bioframe.bedslice(grouped, region) for region in regions
         )
 
     # histogram the signal
@@ -296,6 +296,7 @@ def make_saddle(
 
     """
     digitized_df, name = digitized
+    digitized_df = digitized_df[["chrom","start","end",name]]
 
     if regions is None:
         regions = [
@@ -305,12 +306,10 @@ def make_saddle(
     else:
         regions = [bioframe.parse_region(reg) for reg in regions]
 
-    digitized_tracks = {
-        reg: bioframe.bedslice(digitized_df.groupby("chrom"), reg[0], reg[1], reg[2])[
-            name
-        ]
-        for reg in regions
-    }
+    digitized_tracks = {}
+    for reg in regions:
+        track = bioframe.bedslice(digitized_df, reg)
+        digitized_tracks[reg] = track[name]
 
     if contact_type == "cis":
         supports = list(zip(regions, regions))


### PR DESCRIPTION
- [x] rename supports → regions
- [ ] assign_supports:
    - [ ] Create a function that takes two sets of intervals, where the second is non-overlapping and sorted, and assigns the span of each set 1 interval in set 2 intervals. Make sure that it works with different resolutions, where spans of individual pixels may overflow chromosomal arms. Should end up in bioframe.
    - [ ] rewrite assign_supports as a generic array operation on binspans?.. I.e. overlap a region and a point, but w/o chromosomes. 
    - [ ] modify diagsums to use these new functions
- [ ] bioframe.tools.split_chromosomes 
    - [x] if centromere is missing, assume the split point at 0
    - [ ] Allow BED inputs
    - [ ] multiple split points per chromosome 
- [ ] clean up diag_assym 
    - [ ] what’s this regions1, regions2?..
- [ ] autogenerate transforms from weights? 
- [ ] in bioframe, set up an easy way to generate and retrieve chromosomal arms
- [ ] finalize the format of the expected table 
- [ ] store data inside coolers
