### PR TITLE
Sameer

### DIFF
--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -353,7 +353,7 @@ def cooler_cis_eig(
     eigvals_per_reg, eigvecs_per_reg = zip(*map(_each, regions))
 
     for region, eigvecs in zip(regions, eigvecs_per_reg):
-        lo, hi = bioframe.bisect_bedframe(bins, region)
+        lo, hi = bioframe.bedbisect(bins, region)
         for i, eigvec in enumerate(eigvecs):
             eigvec_table.iloc[
                 lo:hi, eigvec_table.columns.get_loc("E" + str(i + 1))

--- a/cooltools/eigdecomp.py
+++ b/cooltools/eigdecomp.py
@@ -334,7 +334,7 @@ def cooler_cis_eig(
                 'No column "{}" in the bin table'.format(phasing_track_col)
             )
         phasing_track = (
-            bioframe.slice_bedframe(bins, region)[phasing_track_col].values
+            bioframe.bedslice(bins, region)[phasing_track_col].values
             if phasing_track_col
             else None
         )


### PR DESCRIPTION
eigdecomp.cooler_cis_eig was throwing errors because of the new names of the bioframe functions bedslice and bedbisect in the latest version. In the current master branch, cool_cis_eig tries to call slice_bedframe and bisect_bedframe and hence throws errors.

I've changed the names of the functions being called and resolved the errors.